### PR TITLE
Support using a non-root user

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -14,10 +14,8 @@ on:
       - "!CODE_OF_CONDUCT.md.md"
 
 env:
-  # ORGANIZATION: "zenika"
-  # IMAGE_NAME: "terraform-aws-cli"
-  ORGANIZATION: "kstephens"
-  IMAGE_NAME: "nonroot-user"
+  ORGANIZATION: "zenika"
+  IMAGE_NAME: "terraform-aws-cli"
 
 jobs:
   lint:
@@ -42,7 +40,6 @@ jobs:
 
       - name: Save branch name as env var
         run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
-        # run: echo "::set-env name=BRANCH::${GITHUB_REF##*/}"
 
       - name: Build image
         run: docker image build . --file Dockerfile --tag $ORGANIZATION/$IMAGE_NAME:$BRANCH
@@ -66,7 +63,6 @@ jobs:
 
       - name: Save branch name as env var
         run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
-        # run: echo "::set-env name=BRANCH::${GITHUB_REF##*/}"
 
       - name: Download image artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -41,7 +41,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Save branch name as env var
-        run: echo "::set-env name=BRANCH::${GITHUB_REF##*/}"
+        run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+        # run: echo "::set-env name=BRANCH::${GITHUB_REF##*/}"
 
       - name: Build image
         run: docker image build . --file Dockerfile --tag $ORGANIZATION/$IMAGE_NAME:$BRANCH
@@ -64,7 +65,8 @@ jobs:
         uses: actions/checkout@master
 
       - name: Save branch name as env var
-        run: echo "::set-env name=BRANCH::${GITHUB_REF##*/}"
+        run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+        # run: echo "::set-env name=BRANCH::${GITHUB_REF##*/}"
 
       - name: Download image artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -14,8 +14,10 @@ on:
       - "!CODE_OF_CONDUCT.md.md"
 
 env:
-  ORGANIZATION: "zenika"
-  IMAGE_NAME: "terraform-aws-cli"
+  # ORGANIZATION: "zenika"
+  # IMAGE_NAME: "terraform-aws-cli"
+  ORGANIZATION: "kstephens"
+  IMAGE_NAME: "nonroot-user"
 
 jobs:
   lint:

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,8 @@ COPY --from=aws-cli /usr/local/lib/python${PYTHON_MAJOR_VERSION}/dist-packages /
 COPY --from=aws-cli /usr/lib/python3/dist-packages /usr/lib/python3/dist-packages
 
 WORKDIR /workspace
-RUN groupadd -g 65500 nonroot \
-  && useradd -g nonroot -m -u 65500 nonroot \
+RUN groupadd -g 1001 nonroot \
+  && useradd -g nonroot -m -u 1001 nonroot \
   && chown nonroot:nonroot /workspace
 
 USER nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,11 @@ COPY --from=terraform /terraform /usr/local/bin/terraform
 COPY --from=aws-cli /usr/local/bin/aws* /usr/local/bin/
 COPY --from=aws-cli /usr/local/lib/python${PYTHON_MAJOR_VERSION}/dist-packages /usr/local/lib/python${PYTHON_MAJOR_VERSION}/dist-packages
 COPY --from=aws-cli /usr/lib/python3/dist-packages /usr/lib/python3/dist-packages
+
 WORKDIR /workspace
+RUN groupadd -g 65500 nonroot \
+  && useradd -g nonroot -m -u 65500 nonroot \
+  && chown nonroot:nonroot /workspace
+
+USER nonroot
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Tools included:
 * [Git](https://git-scm.com/) for Terraform remote module usage, see available versions on the [Debian Packages repository](https://packages.debian.org/search?suite=buster&arch=any&searchon=names&keywords=git)
 * [jq](https://stedolan.github.io/jq/) to process JSON returned by AWS, see available versions on the [Debian Packages repository](https://packages.debian.org/search?suite=buster&arch=any&searchon=names&keywords=jq)
 
+User:
+
+This image uses a non-root with a uid and gid of 1001 to conform with docker security best practices.
+
 ## 🚀 Usage
 
 ### 🐚 Launch the CLI

--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ Tools included:
 * [Git](https://git-scm.com/) for Terraform remote module usage, see available versions on the [Debian Packages repository](https://packages.debian.org/search?suite=buster&arch=any&searchon=names&keywords=git)
 * [jq](https://stedolan.github.io/jq/) to process JSON returned by AWS, see available versions on the [Debian Packages repository](https://packages.debian.org/search?suite=buster&arch=any&searchon=names&keywords=jq)
 
-User:
-
-This image uses a non-root with a uid and gid of 1001 to conform with docker security best practices.
+This image uses a non-root with a UID and GID of 1001 to conform with docker security best practices.
 
 ## 🚀 Usage
 

--- a/tests/container-structure-tests.yml
+++ b/tests/container-structure-tests.yml
@@ -32,14 +32,3 @@ commandTests:
     command: "aws"
     args: ["--version"]
     expectedOutput: ["aws-cli/1.18.166"]
-
-userTests:
-  - name: "Check current user"
-    command: "id"
-    args: ["-u"]
-    expectedOutput: ["65500"]
-
-  - name: "Check current user group"
-    command: "id"
-    args: ["-g"]
-    expectedOutput: ["65500"]

--- a/tests/container-structure-tests.yml
+++ b/tests/container-structure-tests.yml
@@ -32,3 +32,19 @@ commandTests:
     command: "aws"
     args: ["--version"]
     expectedOutput: ["aws-cli/1.18.166"]
+
+fileExistenceTests:
+  - name: 'Check nonroot user home'
+    path: '/home/nonroot'
+    shouldExist: true
+    permissions: 'drwxr-xr-x'
+    uid: 1001
+    gid: 1001
+    isExecutableBy: 'group'
+  - name: 'Check nonroot user rights on /workspace folder'
+    path: '/workspace'
+    shouldExist: true
+    permissions: 'drwxr-xr-x'
+    uid: 1001
+    gid: 1001
+    isExecutableBy: 'group'

--- a/tests/container-structure-tests.yml
+++ b/tests/container-structure-tests.yml
@@ -32,3 +32,14 @@ commandTests:
     command: "aws"
     args: ["--version"]
     expectedOutput: ["aws-cli/1.18.166"]
+
+userTests:
+  - name: "Check current user"
+    command: "id"
+    args: ["-u"]
+    expectedOutput: ["65500"]
+
+  - name: "Check current user group"
+    command: "id"
+    args: ["-g"]
+    expectedOutput: ["65500"]


### PR DESCRIPTION
I actually needed this functionality (https://github.com/zenika-open-source/terraform-aws-cli/issues/14) for a project, so I thought I would go ahead and open a PR for it. Incidentally, this is my first PR on github, so let me know if I've done anything obviously wrong. Also, thanks for maintaining this very convenient image.

A couple of notes on changes:

The uid and gid for the user/group, as well as the user/group names, are completely arbitrary, so if you would prefer to use different ones, let me know. 

I created a home directory for the user because aws cli wants to write a credentials cache in an .aws directory in the user's home directory. I didn't find any options to change this behavior, and I'm not sure if it would be a good idea anyway.

While running the tests in the gitlab actions, I ran into what looks like a recent change by github, where they've disabled the set-env command for security reasons. This of course caused the tests to fail. To get the tests working again, I updated the variable setting to use the new format following this issue: https://github.com/actions/toolkit/issues/641.

Let me know if you have any comments or suggestions.