### PR TITLE
Add openssh-client to final container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
     git=1:2.30.2-1 \
     jq=1.6-2.1 \
     python3=${PYTHON_MAJOR_VERSION}.2-3 \
+    openssh-client=1:8.4p1-5+deb11u1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_MAJOR_VERSION} 1


### PR DESCRIPTION
Terraform modules can be cloned via HTTP, but some use cases (e.g. cloning from an internal Gitlab module) benefit from cloning over SSH.