### PR TITLE
chore(renovate): configuration étendue avec groupage et custom managers (epic #102)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # ignore generated container structure test config
 tests/container-structure-tests.yml
+
+# Claude Code internal directory
+.claude/

--- a/docs/dependencies-upgrades.md
+++ b/docs/dependencies-upgrades.md
@@ -1,5 +1,26 @@
 # ⬆️ Dependencies upgrades checklist
 
+## Automatisation via Renovate
+
+La gestion des dépendances est en grande partie automatisée via [Renovate](https://docs.renovatebot.com/). La configuration se trouve dans [`renovate.json`](../renovate.json).
+
+### Ce que Renovate gère automatiquement
+
+| Scope | Comportement |
+|---|---|
+| **GitHub Actions** | PRs groupées chaque week-end ; patches/digests automerge |
+| **Image de base Debian** (Dockerfile) | PRs groupées avec les paquets APT |
+| **Dernière version Terraform** (`supported_versions.json`) | PR créée quand une nouvelle release sort sur GitHub |
+| **Dernière version AWS CLI** (`supported_versions.json`) | PR créée quand un nouveau tag sort sur GitHub |
+
+### Ce qui reste manuel après merge d'une PR Renovate sur les versions d'outils
+
+Lorsque Renovate met à jour la dernière version Terraform ou AWS CLI dans `supported_versions.json`, les **fichiers de vérification GPG** associés doivent être ajoutés manuellement dans le répertoire `security/` avant de pouvoir builder l'image. Se référer à [`docs/binaries-verifications.md`](binaries-verifications.md) pour la procédure complète.
+
+---
+
+## Checklist manuelle (hors scope Renovate)
+
 * Supported tools versions:
   * [Report to the doc](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/docs/binaries-verifications.md) to add required security files when adding a new supported versions
   * check available **AWS CLI** version on the [project release page](https://github.com/aws/aws-cli/tags)

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,80 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
+  ],
+  "schedule": ["every weekend"],
+  "labels": ["dependencies"],
+  "commitMessagePrefix": "chore(deps):",
+  "commitMessageAction": "update",
+  "prCreation": "immediate",
+  "packageRules": [
+    {
+      "description": "Automerge patch updates for GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Group all GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "commitMessageTopic": "github actions"
+    },
+    {
+      "description": "Group Debian base image and APT packages",
+      "matchManagers": ["dockerfile"],
+      "matchDepTypes": ["stage", "arg"],
+      "groupName": "Debian base image",
+      "commitMessageTopic": "debian base image"
+    },
+    {
+      "description": "Group Terraform versions in supported_versions.json",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["hashicorp/terraform"],
+      "groupName": "Terraform versions matrix",
+      "commitMessageTopic": "terraform versions matrix"
+    },
+    {
+      "description": "Group AWS CLI versions in supported_versions.json",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["aws/aws-cli"],
+      "groupName": "AWS CLI versions matrix",
+      "commitMessageTopic": "aws cli versions matrix"
+    },
+    {
+      "description": "Remind to update security files when tool versions change",
+      "matchManagers": ["custom.regex"],
+      "prBodyNotes": [
+        "⚠️ **Action manuelle requise** : après merge, télécharger les fichiers de vérification GPG correspondants dans le répertoire `security/` selon la procédure dans `docs/binaries-verifications.md`."
+      ]
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Track latest Terraform version in supported_versions.json",
+      "customType": "regex",
+      "fileMatch": ["^supported_versions\\.json$"],
+      "matchStrings": [
+        "\"tf_versions\":\\s*\\[[^\\]]*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\"\\s*\\]"
+      ],
+      "depNameTemplate": "hashicorp/terraform",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "versioningTemplate": "semver"
+    },
+    {
+      "description": "Track latest AWS CLI version in supported_versions.json",
+      "customType": "regex",
+      "fileMatch": ["^supported_versions\\.json$"],
+      "matchStrings": [
+        "\"awscli_versions\":\\s*\\[[^\\]]*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\"\\s*\\]"
+      ],
+      "depNameTemplate": "aws/aws-cli",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
+    }
   ]
 }


### PR DESCRIPTION
## Résumé

Extension de la configuration Renovate pour couvrir les versions des outils embarqués, grouper les PRs et aligner avec Conventional Commits.

### Changements apportés

**`renovate.json`**

- Remplace `config:base` (déprécié) par `config:recommended`
- Ajoute des **custom regex managers** pour détecter la dernière version dans chaque tableau de `supported_versions.json` :
  - `hashicorp/terraform` via `github-releases` (avec extraction du préfixe `v`)
  - `aws/aws-cli` via `github-tags`
- **Groupage des PRs** par scope :
  - GitHub Actions (avec automerge des patches/digests)
  - Image de base Debian + paquets APT
  - Versions Terraform dans la matrice
  - Versions AWS CLI dans la matrice
- **Conventional Commits** : préfixe `chore(deps):` sur tous les commits Renovate
- **Planning** : mises à jour chaque week-end pour éviter le flood de PRs en semaine
- **Note automatique dans les PRs** d'outils : rappel que les fichiers GPG dans `security/` doivent être ajoutés manuellement

**`docs/dependencies-upgrades.md`**

- Nouvelle section en haut documentant ce que Renovate gère automatiquement
- Tableau récapitulatif des scopes couverts
- Clarification de ce qui reste manuel (fichiers de vérification GPG dans `security/`)

### Ce qui reste manuel

Lorsque Renovate crée une PR pour mettre à jour la dernière version Terraform ou AWS CLI dans `supported_versions.json`, le maintainer doit **avant ou après le merge** :
1. Télécharger les fichiers de vérification GPG correspondants dans `security/`
2. Suivre la procédure dans `docs/binaries-verifications.md`

Renovate le rappelle automatiquement dans le body de chaque PR via `prBodyNotes`.

---

Closes #102
Relates to #20

https://claude.ai/code/session_01RsmDFm6w4jVXwvzmRd9BCv

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsmDFm6w4jVXwvzmRd9BCv)_