### PR TITLE
feat: distribution et nommage de l'image (epic #100)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ on:
       - ".github/workflows/build-test.yml"
 
 env:
-  IMAGE_NAME: "terraform-aws-cli"
+  IMAGE_NAME: "bgauduch/terraform-aws-cli"
 
 jobs:
   load_supported_versions:

--- a/.github/workflows/dockerhub-description-update.yml
+++ b/.github/workflows/dockerhub-description-update.yml
@@ -13,11 +13,11 @@ jobs:
   dockerHubDescription:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Update Docker Hub Description
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PAT }}
-          repository: zenika/terraform-aws-cli
+          repository: bgauduch/terraform-aws-cli

--- a/.github/workflows/push-latest.yml
+++ b/.github/workflows/push-latest.yml
@@ -20,34 +20,49 @@ jobs:
   build_push_latest:
     runs-on: ubuntu-22.04
 
+    permissions:
+      packages: write
+
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Retrieve latest suported versions
+      - name: Retrieve latest supported versions
         run: |
           echo "TF_VERSION=$(jq -r '.tf_versions | sort | .[-1]' supported_versions.json)" >> $GITHUB_ENV
           echo "AWS_VERSION=$(jq -r '.awscli_versions | sort | .[-1]' supported_versions.json)" >> $GITHUB_ENV
 
       - name: Login to Docker Hub registry
-        run: echo '${{ secrets.DOCKERHUB_PAT }}' | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push container images
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
           build-args: |
             TERRAFORM_VERSION=${{ env.TF_VERSION }}
             AWS_CLI_VERSION=${{ env.AWS_VERSION }}
-          tags: zenika/terraform-aws-cli:latest
+          tags: |
+            bgauduch/terraform-aws-cli:latest
+            ghcr.io/bgauduch/terraform-aws-cli:latest
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,21 @@
 name: release
-
-# trigger on published release
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   load_supported_versions:
     runs-on: ubuntu-22.04
-
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
-
-      - name: Save supported versions as output
-        id: set-matrix
+      - uses: actions/checkout@v4
+      - id: set-matrix
         run: |
           VERSIONS=$(cat ./supported_versions.json | jq -c)
           echo "matrix=${VERSIONS}" >> $GITHUB_OUTPUT
@@ -25,39 +23,74 @@ jobs:
   build_push_release:
     runs-on: ubuntu-22.04
     needs: load_supported_versions
-
     strategy:
       matrix: ${{ fromJSON(needs.load_supported_versions.outputs.matrix) }}
-
-    env:
-      ORGANIZATION: "zenika"
-      IMAGE_NAME: "terraform-aws-cli"
-
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Get and save the release tag
-        run: echo "RELEASE_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Compute tag variants
+        run: |
+          TF_MINOR=$(echo "${{ matrix.tf_versions }}" | cut -d. -f1-2)
+          AWS_MINOR=$(echo "${{ matrix.awscli_versions }}" | cut -d. -f1-2)
+          LATEST_TF=$(jq -r '.tf_versions | sort | .[-1]' supported_versions.json)
+          LATEST_AWS=$(jq -r '.awscli_versions | sort | .[-1]' supported_versions.json)
+          IS_LATEST=$([[ "${{ matrix.tf_versions }}" == "$LATEST_TF" && "${{ matrix.awscli_versions }}" == "$LATEST_AWS" ]] && echo "true" || echo "false")
+          echo "TF_MINOR=${TF_MINOR}" >> $GITHUB_ENV
+          echo "AWS_MINOR=${AWS_MINOR}" >> $GITHUB_ENV
+          echo "IS_LATEST=${IS_LATEST}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub registry
-        run: echo '${{ secrets.DOCKERHUB_PAT }}' | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Build and push container images
-        uses: docker/build-push-action@v4
+      - name: Build and push (non-latest)
+        if: env.IS_LATEST != 'true'
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
           build-args: |
             TERRAFORM_VERSION=${{ matrix.tf_versions }}
             AWS_CLI_VERSION=${{ matrix.awscli_versions }}
-          tags: zenika/terraform-aws-cli:release-${{ env.RELEASE_TAG }}_terraform-${{ matrix.tf_versions }}_awscli-${{ matrix.awscli_versions }}
+          tags: |
+            bgauduch/terraform-aws-cli:${{ github.ref_name }}_tf-${{ matrix.tf_versions }}_aws-${{ matrix.awscli_versions }}
+            bgauduch/terraform-aws-cli:tf-${{ env.TF_MINOR }}_aws-${{ env.AWS_MINOR }}
+            ghcr.io/bgauduch/terraform-aws-cli:${{ github.ref_name }}_tf-${{ matrix.tf_versions }}_aws-${{ matrix.awscli_versions }}
+            ghcr.io/bgauduch/terraform-aws-cli:tf-${{ env.TF_MINOR }}_aws-${{ env.AWS_MINOR }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push (latest)
+        if: env.IS_LATEST == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          build-args: |
+            TERRAFORM_VERSION=${{ matrix.tf_versions }}
+            AWS_CLI_VERSION=${{ matrix.awscli_versions }}
+          tags: |
+            bgauduch/terraform-aws-cli:${{ github.ref_name }}_tf-${{ matrix.tf_versions }}_aws-${{ matrix.awscli_versions }}
+            bgauduch/terraform-aws-cli:tf-${{ env.TF_MINOR }}_aws-${{ env.AWS_MINOR }}
+            bgauduch/terraform-aws-cli:latest
+            bgauduch/terraform-aws-cli:${{ github.ref_name }}
+            ghcr.io/bgauduch/terraform-aws-cli:${{ github.ref_name }}_tf-${{ matrix.tf_versions }}_aws-${{ matrix.awscli_versions }}
+            ghcr.io/bgauduch/terraform-aws-cli:tf-${{ env.TF_MINOR }}_aws-${{ env.AWS_MINOR }}
+            ghcr.io/bgauduch/terraform-aws-cli:latest
+            ghcr.io/bgauduch/terraform-aws-cli:${{ github.ref_name }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -1,30 +1,35 @@
-[![lint-dockerfile](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/lint-dockerfile.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/lint-dockerfile.yml)
-[![build-test](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/build-test.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/build-test.yml)
-[![push-latest](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/push-latest.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/push-latest.yml)
-[![release](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/release.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/release.yml)
+[![lint-dockerfile](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/lint-dockerfile.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/lint-dockerfile.yml)
+[![build-test](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/build-test.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/build-test.yml)
+[![push-latest](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/push-latest.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/push-latest.yml)
+[![release](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/release.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/release.yml)
 
-[![dockerhub-description-update](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml)
+[![dockerhub-description-update](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Docker Pulls](https://img.shields.io/docker/pulls/zenika/terraform-aws-cli.svg)](https://hub.docker.com/r/zenika/terraform-aws-cli/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/bgauduch/terraform-aws-cli.svg)](https://hub.docker.com/r/bgauduch/terraform-aws-cli/)
 
 # Terraform and AWS CLI Docker image
 
 ## 📦 Supported tags and respective Dockerfile links
 
-Available image tags can be found on the Docker Hub registry: [zenika/terraform-aws-cli](https://hub.docker.com/r/zenika/terraform-aws-cli/tags)
+The image is available on two registries:
 
-Supported versions are listed in the [`supported_versions.json`](https://github.com/Zenika/terraform-aws-cli/blob/master/supported_versions.json) file.
+- **Docker Hub**: [bgauduch/terraform-aws-cli](https://hub.docker.com/r/bgauduch/terraform-aws-cli/tags)
+- **GitHub Container Registry**: [ghcr.io/bgauduch/terraform-aws-cli](https://github.com/bgauduch/terraform-aws-cli/pkgs/container/terraform-aws-cli)
+
+Supported versions are listed in the [`supported_versions.json`](https://github.com/bgauduch/terraform-aws-cli/blob/master/supported_versions.json) file.
 
 The following image tag strategy is applied:
 
-* `zenika/terraform-aws-cli:latest` - build from master
-  * Included CLI versions are the latest in [`supported_versions.json`](https://github.com/Zenika/terraform-aws-cli/blob/master/supported_versions.json) file.
-* `zenika/terraform-aws-cli:release-S.T_terraform-UU.VV.WW_awscli-XX.YY.ZZ` - build from releases
-  * `release-S.T` is the release tag
-  * `terraform-UU.VV.WWW` is the **Terraform** version included in the image
-  * `awscli-XX.YY.ZZ` is the **AWS CLI** version included in the image
+* `bgauduch/terraform-aws-cli:latest` / `ghcr.io/bgauduch/terraform-aws-cli:latest` - build from master
+  * Included CLI versions are the latest in [`supported_versions.json`](https://github.com/bgauduch/terraform-aws-cli/blob/master/supported_versions.json) file.
+* `bgauduch/terraform-aws-cli:vX.Y.Z_tf-A.B.C_aws-D.E.F` / `ghcr.io/bgauduch/terraform-aws-cli:vX.Y.Z_tf-A.B.C_aws-D.E.F` - build from releases (full pinned tag)
+  * `vX.Y.Z` is the release version tag
+  * `tf-A.B.C` is the **Terraform** version included in the image
+  * `aws-D.E.F` is the **AWS CLI** version included in the image
+* `bgauduch/terraform-aws-cli:tf-A.B_aws-D.E` / `ghcr.io/bgauduch/terraform-aws-cli:tf-A.B_aws-D.E` - floating minor version tags
+  * Always point to the latest release for the given minor versions of Terraform and AWS CLI
 
-Please report to the [releases page](https://github.com/Zenika/terraform-aws-cli/releases) for the changelogs.
+Please report to the [releases page](https://github.com/bgauduch/terraform-aws-cli/releases) for the changelogs.
 
 > Any other tags are not supported even if available.
 
@@ -49,14 +54,20 @@ Tools included:
 
 ### 🐚 Launch the CLI
 
-Set your AWS credentials (optional) and use the CLI as you would on any other platform, for instance using the latest image:
+Set your AWS credentials (optional) and use the CLI as you would on any other platform, for instance using the latest image from Docker Hub:
 
 ```bash
 echo AWS_ACCESS_KEY_ID=YOUR_ACCESS_KEY
 echo AWS_SECRET_ACCESS_KEY=YOUR_SECRET_KEY
 echo AWS_DEFAULT_REGION=YOUR_DEFAULT_REGION
 
-docker container run -it --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" -v ${PWD}:/workspace zenika/terraform-aws-cli:latest
+docker container run -it --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" -v ${PWD}:/workspace bgauduch/terraform-aws-cli:latest
+```
+
+Or pull from the GitHub Container Registry:
+
+```bash
+docker container run -it --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" -v ${PWD}:/workspace ghcr.io/bgauduch/terraform-aws-cli:latest
 ```
 
 > The `--rm` flag will completely destroy the container and its data on exit.
@@ -68,7 +79,7 @@ The image can be built locally directly from the Dockerfiles, using the build sc
 It will :
 
 * Lint the Dockerfile with [Hadolint](https://github.com/hadolint/hadolint);
-* Build and tag the image `zenika/terraform-aws-cli:dev`;
+* Build and tag the image `bgauduch/terraform-aws-cli:dev`;
 * Execute [container structure tests](https://github.com/GoogleContainerTools/container-structure-test) on the image.
 
 ```bash
@@ -88,18 +99,16 @@ TERRAFORM_VERSION=1.5.2
 ```
 
 ## 🙏 Contributions
-Do not hesitate to contribute by [filling an issue](https://github.com/Zenika/terraform-aws-cli/issues) or [a PR](https://github.com/Zenika/terraform-aws-cli/pulls) !
+Do not hesitate to contribute by [filling an issue](https://github.com/bgauduch/terraform-aws-cli/issues) or [a PR](https://github.com/bgauduch/terraform-aws-cli/pulls) !
 
 ## 📚 Documentations
 
-* [Dependencies upgrades checklist](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/docs/dependencies-upgrades.md)
-* [Binaries verifications](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/docs/binaries-verifications.md)
+* [Dependencies upgrades checklist](https://github.com/bgauduch/terraform-aws-cli/tree/master/docs/dependencies-upgrades.md)
+* [Binaries verifications](https://github.com/bgauduch/terraform-aws-cli/tree/master/docs/binaries-verifications.md)
 
 ## 🚩 Similar repositories
 
 * For Azure: [zenika-open-source/terraform-azure-cli](https://github.com/zenika-open-source/terraform-azure-cli)
 
 ## 📖 License
-This project is under the [Apache License 2.0](https://raw.githubusercontent.com/Zenika/terraform-aws-cli/master/LICENSE)
-
-[![with love by zenika](https://img.shields.io/badge/With%20%E2%9D%A4%EF%B8%8F%20by-Zenika-b51432.svg)](https://oss.zenika.com)
+This project is under the [Apache License 2.0](https://raw.githubusercontent.com/bgauduch/terraform-aws-cli/master/LICENSE)

--- a/dev.sh
+++ b/dev.sh
@@ -10,7 +10,7 @@ set -eo pipefail
 [[ -n $2 ]] && TF_VERSION=$2 || TF_VERSION=$(jq -r '.tf_versions | sort | .[-1]' supported_versions.json)
 
 # Set image name and tag (dev if not specified)
-IMAGE_NAME="zenika/terraform-aws-cli"
+IMAGE_NAME="bgauduch/terraform-aws-cli"
 [[ -n $3 ]] && IMAGE_TAG=$3 || IMAGE_TAG="dev"
 
 # Set platform for Hadolint image (only linux/arm64 or linux/arm64 supported)


### PR DESCRIPTION
## Summary

- **Renommage de l'image** : `zenika/terraform-aws-cli` → `bgauduch/terraform-aws-cli` dans tous les workflows, `README.md` et `dev.sh`
- **Ajout de GHCR** : `ghcr.io/bgauduch/terraform-aws-cli` comme second registry ; les images sont poussées simultanément sur DockerHub et GHCR
- **Nouvelle stratégie de tags** : tags complets `vX.Y.Z_tf-A.B.C_aws-D.E.F`, floating minor tags `tf-A.B_aws-D.E`, et `latest` / `vX.Y.Z` uniquement pour la dernière combinaison de versions
- **Modernisation de l'authentification** : remplacement du `echo | docker login` manuel par `docker/login-action@v3` pour DockerHub et GHCR ; ajout de `permissions: packages: write` pour l'accès GHCR

## Changes

### Workflows
- `push-latest.yml` : login DockerHub et GHCR via `docker/login-action@v3`, `permissions.packages: write`, push des tags `latest` sur les deux registries, mise à jour des actions Docker vers v3/v6
- `release.yml` : trigger sur `push tags v*` (au lieu de `release: published`), `permissions: contents: read / packages: write`, calcul des minor versions (`TF_MINOR`, `AWS_MINOR`, `IS_LATEST`), deux steps de build conditionnels (non-latest / latest), push sur DockerHub et GHCR simultanément
- `build-test.yml` : renommage `IMAGE_NAME` → `bgauduch/terraform-aws-cli`
- `dockerhub-description-update.yml` : `repository` mis à jour, `actions/checkout` passé en v4

### Documentation
- `README.md` : mention des deux registries, nouvelle stratégie de tags documentée, exemples d'utilisation Docker Hub et GHCR, suppression des références Zenika
- `dev.sh` : `IMAGE_NAME` mis à jour

## Test plan

- [ ] Vérifier que `push-latest.yml` se déclenche sur push master et pousse sur DockerHub et GHCR
- [ ] Vérifier que `release.yml` se déclenche sur un tag `v*` et génère les bons tags pour chaque combinaison
- [ ] Vérifier que la combinaison `IS_LATEST=true` produit également les tags `latest` et `vX.Y.Z`
- [ ] Vérifier que `build-test.yml` s'exécute sans push (build local uniquement)
- [ ] Vérifier que `dockerhub-description-update.yml` met à jour la description DockerHub

Closes #100
Closes #60

https://claude.ai/code/session_01RsmDFm6w4jVXwvzmRd9BCv

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsmDFm6w4jVXwvzmRd9BCv)_