### PR TITLE
feat: supply chain security - trivy, sbom, cosign (epic #99)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,6 +18,17 @@ on:
       - ".dockerignore"
       - "hadolint.yaml"
       - ".github/workflows/build-test.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile"
+      - "supported_versions.json"
+      - "tests/**"
+      - ".github/workflows/build-test.yml"
+
+permissions:
+  contents: read
 
 env:
   IMAGE_NAME: "terraform-aws-cli"
@@ -74,6 +85,16 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL
 
       - name: Generate test config
         run: |

--- a/.github/workflows/dockerhub-description-update.yml
+++ b/.github/workflows/dockerhub-description-update.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - README.md
       - .github/workflows/dockerhub-description.yml
+permissions:
+  contents: read
+
 jobs:
   dockerHubDescription:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint-dockerfile.yml
+++ b/.github/workflows/lint-dockerfile.yml
@@ -14,6 +14,9 @@ on:
       - "Dockerfile"
       - ".github/workflows/lint-dockerfile.yml"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/push-latest.yml
+++ b/.github/workflows/push-latest.yml
@@ -16,6 +16,10 @@ on:
       - "supported_platforms.json"
       - "tests/**"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build_push_latest:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write  # required for cosign keyless OIDC signing
+
 jobs:
   load_supported_versions:
     runs-on: ubuntu-22.04
@@ -61,3 +66,26 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0.24.0
+        with:
+          image: zenika/terraform-aws-cli:release-${{ env.RELEASE_TAG }}_terraform-${{ matrix.tf_versions }}_awscli-${{ matrix.awscli_versions }}
+          format: spdx-json
+          output-file: sbom-tf${{ matrix.tf_versions }}-aws${{ matrix.awscli_versions }}.spdx.json
+
+      - name: Upload SBOM to release
+        uses: anchore/sbom-action/publish-sbom@v0.24.0
+        with:
+          sbom-artifact-match: ".*\\.spdx\\.json$"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.1
+
+      - name: Sign published image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' \
+            zenika/terraform-aws-cli:release-${{ env.RELEASE_TAG }}_terraform-${{ matrix.tf_versions }}_awscli-${{ matrix.awscli_versions }})
+          cosign sign --yes "${IMAGE_DIGEST}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is actively supported with security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues.
+
+Instead, report them by opening a [GitHub Security Advisory](https://github.com/bgauduch/terraform-aws-cli/security/advisories/new).
+
+You can expect:
+- **Acknowledgement** within 48 hours
+- **Status update** within 7 days
+- **Fix or mitigation** within 90 days depending on severity
+
+## Security Measures
+
+This project implements the following supply chain security measures:
+
+- **Binary verification**: Terraform and AWS CLI binaries are verified using GPG signatures and SHA256 checksums before inclusion in the image
+- **Non-root container**: The image runs as a non-root user (`nonroot`, UID 1001)
+- **Minimal base image**: Uses Debian slim to reduce attack surface
+- **Vulnerability scanning**: Images are scanned with [Trivy](https://github.com/aquasecurity/trivy) on every build
+- **SBOM**: A Software Bill of Materials (SPDX format) is attached to every release
+- **Image signing**: Released images are signed using [cosign](https://github.com/sigstore/cosign) with keyless signing (Sigstore)
+
+### Verifying image signatures
+
+```bash
+cosign verify ghcr.io/bgauduch/terraform-aws-cli:<tag> \
+  --certificate-identity-regexp="https://github.com/bgauduch/terraform-aws-cli/.github/workflows/release.yml@refs/tags/.*" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```


### PR DESCRIPTION
## Summary

Implements epic #99 — supply chain security hardening across the CI/CD pipeline.

### Changes

- **Trivy vulnerability scanning** (`build-test.yml`): Adds a scan step after the Docker build (amd64 test image) using `aquasecurity/trivy-action@0.36.0`. Scans OS and library packages, fails the build on unfixed CRITICAL vulnerabilities.

- **SBOM generation** (`release.yml`): After each release image push, generates a SPDX-JSON Software Bill of Materials using `anchore/sbom-action@v0.24.0` and uploads it as a release asset via `anchore/sbom-action/publish-sbom`.

- **Cosign keyless image signing** (`release.yml`): After each release image push, signs the image digest using `sigstore/cosign-installer@v4.1.1` with keyless OIDC signing (Sigstore). No long-lived keys required.

- **Least-privilege permissions** (all workflows): Adds explicit `permissions:` blocks at the workflow level to enforce minimum required permissions:
  - `lint-dockerfile.yml`: `contents: read`
  - `build-test.yml`: `contents: read`
  - `push-latest.yml`: `contents: read`, `packages: write`
  - `release.yml`: `contents: read`, `packages: write`, `id-token: write` (required for cosign OIDC)
  - `dockerhub-description-update.yml`: `contents: read`

- **PR trigger** (`build-test.yml`): Adds `pull_request` trigger targeting `master` so vulnerability scans run on PRs before merge.

- **SECURITY.md**: Responsible disclosure policy, supported versions, security measures overview, and instructions for verifying image signatures with cosign.

## Verifying signed images

```bash
cosign verify ghcr.io/bgauduch/terraform-aws-cli:<tag> \
  --certificate-identity-regexp="https://github.com/bgauduch/terraform-aws-cli/.github/workflows/release.yml@refs/tags/.*" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
```

## Test plan

- [ ] Push a branch with a Dockerfile change and verify the Trivy scan step runs and blocks on CRITICAL unfixed CVEs
- [ ] Open a PR targeting master and verify the `build-test` workflow triggers via the `pull_request` event
- [ ] Publish a release and verify: SBOM `.spdx.json` files are attached to the release assets, cosign signs the image digest without error
- [ ] Confirm `id-token: write` permission is present in `release.yml` (required for keyless OIDC signing)
- [ ] Validate all workflow YAML files are syntactically valid

Closes #99

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsmDFm6w4jVXwvzmRd9BCv)_