### PR TITLE
fix: qualité du code - dev.sh, dockerfile layers, tests (epic #104)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 FROM debian:${DEBIAN_VERSION} as terraform
 ARG TARGETARCH
 ARG TERRAFORM_VERSION
-RUN apt-get update
-# RUN apt-get install --no-install-recommends -y libcurl4=7.74.0-1.3+deb11u7
-RUN apt-get install --no-install-recommends -y ca-certificates=20230311
-RUN apt-get install --no-install-recommends -y curl=7.88.1-10+deb12u4
-RUN apt-get install --no-install-recommends -y gnupg=2.2.40-1.1
-RUN apt-get install --no-install-recommends -y unzip=6.0-28
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    ca-certificates=20230311 \
+    curl=7.88.1-10+deb12u4 \
+    gnupg=2.2.40-1.1 \
+    unzip=6.0-28 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 WORKDIR /workspace
 RUN curl --silent --show-error --fail --remote-name https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip
 COPY security/hashicorp.asc ./
@@ -26,13 +28,16 @@ RUN unzip -j terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip
 # Install AWS CLI version 2
 FROM debian:${DEBIAN_VERSION} as aws-cli
 ARG AWS_CLI_VERSION
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends ca-certificates=20230311
-RUN apt-get install -y --no-install-recommends curl=7.88.1-10+deb12u4
-RUN apt-get install -y --no-install-recommends gnupg=2.2.40-1.1
-RUN apt-get install -y --no-install-recommends unzip=6.0-28
-RUN apt-get install -y --no-install-recommends git=1:2.39.2-1.1
-RUN apt-get install -y --no-install-recommends jq=1.6-2.1
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates=20230311 \
+    curl=7.88.1-10+deb12u4 \
+    gnupg=2.2.40-1.1 \
+    unzip=6.0-28 \
+    git=1:2.39.2-1.1 \
+    jq=1.6-2.1 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 WORKDIR /workspace
 RUN curl --show-error --fail --output "awscliv2.zip" --remote-name "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip"
 COPY security/awscliv2.asc ./

--- a/dev.sh
+++ b/dev.sh
@@ -1,27 +1,58 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -euo pipefail
 
-# FIXME: use getopts function to parse aguments
-# FIXME: if provided, both TF and AWS CLI semvers should be regex-validated
+trap 'echo "Error: script failed at line ${LINENO}" >&2' ERR
+
+usage() {
+  echo "Usage: $0 [-a AWS_CLI_VERSION] [-t TF_VERSION] [-i IMAGE_TAG]"
+  echo "  -a  AWS CLI version (default: latest from supported_versions.json)"
+  echo "  -t  Terraform version (default: latest from supported_versions.json)"
+  echo "  -i  Image tag (default: dev)"
+  exit 1
+}
+
+while getopts "a:t:i:h" opt; do
+  case ${opt} in
+    a) AWS_VERSION="${OPTARG}" ;;
+    t) TF_VERSION="${OPTARG}" ;;
+    i) IMAGE_TAG="${OPTARG}" ;;
+    h) usage ;;
+    *) usage ;;
+  esac
+done
 
 # Set AWS and TF CLI to latest supported versions if not specified
-[[ -n $1 ]] && AWS_VERSION=$1 || AWS_VERSION=$(jq -r '.awscli_versions | sort | .[-1]' supported_versions.json)
-[[ -n $2 ]] && TF_VERSION=$2 || TF_VERSION=$(jq -r '.tf_versions | sort | .[-1]' supported_versions.json)
+AWS_VERSION="${AWS_VERSION:-$(jq -r '.awscli_versions | sort | .[-1]' supported_versions.json)}"
+TF_VERSION="${TF_VERSION:-$(jq -r '.tf_versions | sort | .[-1]' supported_versions.json)}"
 
 # Set image name and tag (dev if not specified)
 IMAGE_NAME="zenika/terraform-aws-cli"
-[[ -n $3 ]] && IMAGE_TAG=$3 || IMAGE_TAG="dev"
+IMAGE_TAG="${IMAGE_TAG:-dev}"
 
-# Set platform for Hadolint image (only linux/arm64 or linux/arm64 supported)
-PLATEFORM="linux/$(uname -m)"
+SEMVER_REGEX="^[0-9]+\.[0-9]+\.[0-9]+$"
+
+validate_semver() {
+  local version="$1"
+  local name="$2"
+  if [[ ! "${version}" =~ ${SEMVER_REGEX} ]]; then
+    echo "Error: ${name} '${version}' is not a valid semver (expected X.Y.Z)"
+    exit 1
+  fi
+}
+
+validate_semver "${AWS_VERSION}" "AWS_CLI_VERSION"
+validate_semver "${TF_VERSION}" "TERRAFORM_VERSION"
+
+# Set platform for Hadolint image (only linux/amd64 or linux/arm64 supported)
+PLATFORM="linux/$(uname -m)"
 
 # Lint Dockerfile
 echo "Linting Dockerfile..."
 docker container run --rm --interactive \
   --volume "${PWD}":/data \
   --workdir /data \
-  --platform "${PLATEFORM}" \
+  --platform "${PLATFORM}" \
   hadolint/hadolint:2.12.0-alpine /bin/hadolint \
   --config hadolint.yaml Dockerfile
 echo "Lint Successful!"
@@ -30,7 +61,7 @@ echo "Lint Successful!"
 echo "Building images with AWS_CLI_VERSION=${AWS_VERSION} and TERRAFORM_VERSION=${TF_VERSION}..."
 docker buildx build \
   --progress plain \
-  --platform "${PLATEFORM}" \
+  --platform "${PLATFORM}" \
   --build-arg AWS_CLI_VERSION="${AWS_VERSION}" \
   --build-arg TERRAFORM_VERSION="${TF_VERSION}" \
   --tag ${IMAGE_NAME}:${IMAGE_TAG} .

--- a/tests/container-structure-tests.yml.template
+++ b/tests/container-structure-tests.yml.template
@@ -33,6 +33,31 @@ commandTests:
     args: ["--version"]
     expectedOutput: ["aws-cli/${AWS_VERSION}"]
 
+  - name: "Check terraform is in PATH"
+    command: "which"
+    args: ["terraform"]
+    expectedOutput: ["/usr/local/bin/terraform"]
+
+  - name: "Check aws is in PATH"
+    command: "which"
+    args: ["aws"]
+    expectedOutput: ["/usr/local/bin/aws"]
+
+  - name: "Check running as non-root user"
+    command: "id"
+    args: ["-u"]
+    expectedOutput: ["1001"]
+
+  - name: "Check running as nonroot user"
+    command: "id"
+    args: ["-un"]
+    expectedOutput: ["nonroot"]
+
+  - name: "Check HOME directory is set"
+    command: "sh"
+    args: ["-c", "echo $HOME"]
+    expectedOutput: ["/home/nonroot"]
+
 fileExistenceTests:
   - name: 'Check non-root user home'
     path: '/home/nonroot'


### PR DESCRIPTION
## Summary

- **`dev.sh` - getopts et validation semver** : remplace le parsing positionnel (`$1`, `$2`, `$3`) par `getopts` avec les flags `-a` (AWS version), `-t` (TF version), `-i` (image tag). Ajoute une validation regex semver (`X.Y.Z`) sur les deux versions avant utilisation. Ajoute `set -euo pipefail` complet (le `-u` manquait) et un `trap ERR` pour afficher la ligne d'échec.
- **`dev.sh` - typo PLATFORM** : corrige `PLATEFORM` → `PLATFORM` dans le script (variable et commentaire).
- **`Dockerfile` - consolidation des layers** : fusionne les 4–6 `RUN apt-get install` séparés des stages `terraform` et `aws-cli` en un seul `RUN` par stage avec `apt-get clean && rm -rf /var/lib/apt/lists/*`. Les versions pinnées sont inchangées.
- **Tests de structure** : ajoute 5 nouveaux `commandTests` dans `container-structure-tests.yml.template` : vérification que `terraform` et `aws` sont dans `PATH`, que l'utilisateur courant est `nonroot` (uid `1001`), et que `$HOME` vaut `/home/nonroot`.

## Test plan

- [ ] Vérifier que `dev.sh -h` affiche l'usage correctement
- [ ] Vérifier que `dev.sh -a 2.x.y -t 1.x.y` parse correctement les arguments
- [ ] Vérifier que `dev.sh -a invalid` retourne une erreur semver claire
- [ ] Vérifier que le build Docker fonctionne avec les stages `terraform` et `aws-cli` consolidés
- [ ] Exécuter les container structure tests et valider les 5 nouveaux tests

Closes #104

https://claude.ai/code/session_01RsmDFm6w4jVXwvzmRd9BCv

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsmDFm6w4jVXwvzmRd9BCv)_