### PR TITLE
ci: amélioration des workflows - concurrency, pr triggers, cache (epic #103)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,5 +101,6 @@ jobs:
             AWS_CLI_VERSION=${{ matrix.awscli_versions }}
           tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           push: false
+          load: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,6 +19,10 @@ on:
       - "hadolint.yaml"
       - ".github/workflows/build-test.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_NAME: "terraform-aws-cli"
 

--- a/.github/workflows/dockerhub-description-update.yml
+++ b/.github/workflows/dockerhub-description-update.yml
@@ -9,6 +9,11 @@ on:
     paths:
       - README.md
       - .github/workflows/dockerhub-description.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   dockerHubDescription:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint-dockerfile.yml
+++ b/.github/workflows/lint-dockerfile.yml
@@ -14,6 +14,10 @@ on:
       - "Dockerfile"
       - ".github/workflows/lint-dockerfile.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint-dockerfile.yml
+++ b/.github/workflows/lint-dockerfile.yml
@@ -12,6 +12,14 @@ on:
       - "!master"
     paths:
       - "Dockerfile"
+      - "hadolint.yaml"
+      - ".github/workflows/lint-dockerfile.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Dockerfile"
+      - "hadolint.yaml"
       - ".github/workflows/lint-dockerfile.yml"
 
 concurrency:

--- a/.github/workflows/push-latest.yml
+++ b/.github/workflows/push-latest.yml
@@ -3,6 +3,7 @@ name: push-latest
 # trigger on push to master
 # only on Dockerfile related modifications
 on:
+  workflow_dispatch:
   push:
     branches:
       - "master"

--- a/.github/workflows/push-latest.yml
+++ b/.github/workflows/push-latest.yml
@@ -16,6 +16,10 @@ on:
       - "supported_platforms.json"
       - "tests/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build_push_latest:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   load_supported_versions:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

Cette PR modernise les 5 workflows GitHub Actions du dépôt en apportant les améliorations suivantes :

### 1. Contrôle de concurrence (`concurrency`) sur tous les workflows

Évite l'accumulation de runs obsolètes sur la même branche ou PR :

- **`build-test.yml`** et **`lint-dockerfile.yml`** : `cancel-in-progress: true` — les runs en cours sont annulés au profit du nouveau run (comportement souhaité sur les branches feature)
- **`push-latest.yml`**, **`release.yml`** et **`dockerhub-description-update.yml`** : `cancel-in-progress: false` — on évite les doublons sans interrompre un déploiement/release en cours

### 2. Déclenchement sur Pull Request pour `lint-dockerfile.yml`

Le lint Dockerfile se déclenche désormais aussi sur les PR ciblant `master`, en plus des push sur les branches feature. Le path `hadolint.yaml` a également été ajouté aux triggers `push` pour cohérence.

### 3. `load: false` explicite sur le build multi-arch dans `build-test.yml`

Le second step de build (multi-arch : `linux/amd64,linux/arm64,linux/arm/v7,linux/386`) déclare maintenant explicitement `load: false` — confirmant qu'il sert uniquement à vérifier que la compilation multi-plateforme réussit, sans charger l'image localement ni la pousser.

### 4. Cache buildx harmonisé (vérification)

Tous les workflows utilisant `docker/build-push-action` utilisaient déjà la même stratégie de cache :
```yaml
cache-from: type=gha
cache-to: type=gha,mode=max
```
Aucune modification nécessaire — configuration déjà cohérente.

### 5. Déclenchement manuel (`workflow_dispatch`) pour `push-latest.yml`

Le workflow de push vers Docker Hub peut désormais être déclenché manuellement depuis l'UI GitHub, sans nécessiter un push sur `master`.

---

closes #103
closes #46
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsmDFm6w4jVXwvzmRd9BCv)_