### PR TITLE
docs: framework foundation — unified roadmap, ADRs and enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Code owners — required reviewers on structural and decision paths.
+# See docs/roadmap.md and docs/adr/README.md.
+
+# Default owner
+*                       @bgauduch
+
+# Architecture decisions and the roadmap (the source of truth)
+/docs/adr/              @bgauduch
+/docs/roadmap.md        @bgauduch
+
+# Structural paths (changes here normally require an ADR)
+/Dockerfile             @bgauduch
+/.github/workflows/     @bgauduch
+/supported_versions.json @bgauduch
+/security/              @bgauduch
+/renovate.json          @bgauduch
+/.claude/               @bgauduch

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Roadmap phase / closes: <!-- e.g. Phase 1 — closes #105 -->
 ## Architecture Decision Record
 
 <!-- A structural change (Dockerfile, workflows, supported_versions.json, release/
-commit/dependency config, or the Claude framework) requires an ADR. See docs/adr/. -->
+commit/dependency config, or the agent framework `.claude/`) requires an ADR. See docs/adr/. -->
 
 - [ ] This PR adds/updates an ADR under `docs/adr/` (link: ____)
 - [ ] This PR is **not** a structural change — no ADR needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+PR title MUST follow Conventional Commits (type(scope): subject) — it becomes
+the squash-merge subject and feeds the release-please changelog. See docs/roadmap.md.
+-->
+
+## Summary
+
+<!-- What does this PR change and why? Reference the roadmap phase / issue. -->
+
+Roadmap phase / closes: <!-- e.g. Phase 1 — closes #105 -->
+
+## Architecture Decision Record
+
+<!-- A structural change (Dockerfile, workflows, supported_versions.json, release/
+commit/dependency config, or the Claude framework) requires an ADR. See docs/adr/. -->
+
+- [ ] This PR adds/updates an ADR under `docs/adr/` (link: ____)
+- [ ] This PR is **not** a structural change — no ADR needed
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits
+- [ ] Commits are scoped and reviewable
+- [ ] Docs / roadmap updated if behaviour or policy changed
+- [ ] Touches only files within the declared phase scope

--- a/.github/workflows/adr-check.yml
+++ b/.github/workflows/adr-check.yml
@@ -1,0 +1,63 @@
+name: adr-check
+
+# Enforce that structural changes ship with an ADR.
+# A PR that modifies structural paths (or carries the `needs-adr` label) must add
+# a new docs/adr/NNNN-*.md. Apply the `adr-not-needed` label to bypass.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  adr-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require an ADR for structural changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          if printf '%s' "$LABELS" | grep -qw 'adr-not-needed'; then
+            echo "::notice::'adr-not-needed' label present — skipping ADR check."
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          echo "Changed files:"; echo "$changed"
+
+          # Paths considered structural.
+          structural_re='^(Dockerfile|\.github/workflows/|supported_versions\.json|renovate\.json|\.releaserc|release-please|\.commitlintrc|\.claude/|\.github/dependabot\.yml)'
+
+          needs_adr=false
+          if printf '%s' "$LABELS" | grep -qw 'needs-adr'; then
+            needs_adr=true
+          fi
+          if echo "$changed" | grep -Eq "$structural_re"; then
+            needs_adr=true
+          fi
+
+          if [ "$needs_adr" = false ]; then
+            echo "::notice::No structural paths touched — ADR not required."
+            exit 0
+          fi
+
+          if echo "$changed" | grep -Eq '^docs/adr/[0-9]{4}-.+\.md$'; then
+            echo "::notice::Structural change includes an ADR. ✅"
+            exit 0
+          fi
+
+          echo "::error::Structural change detected but no docs/adr/NNNN-*.md added."
+          echo "Add an ADR (see docs/adr/README.md) or apply the 'adr-not-needed' label."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # ignore generated container structure test config
 tests/container-structure-tests.yml
+
+# Claude / Entire local (personal) overrides — never committed
+.claude/settings.local.json
+.entire/settings.local.json

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,34 @@
+# NNNN — <short decision title>
+
+- Status: Proposed | Accepted | Superseded by ADR-XXXX
+- Date: YYYY-MM-DD
+- Deciders: <who>
+
+## Context and problem statement
+
+<What is the issue we're seeing that motivates this decision? 2–4 sentences.>
+
+## Decision drivers
+
+- <driver / constraint>
+- <driver / constraint>
+
+## Considered options
+
+- <option 1>
+- <option 2>
+- <option 3>
+
+## Decision outcome
+
+Chosen option: **<option>**, because <justification>.
+
+### Consequences
+
+- Good: <positive consequence>
+- Bad / cost: <negative consequence or trade-off>
+- Follow-ups: <links to roadmap phase, issues, other ADRs>
+
+## More information
+
+<Links, references, related ADRs. Mark superseded ADRs with a pointer.>

--- a/docs/adr/0001-adopt-unified-roadmap-and-agent-framework.md
+++ b/docs/adr/0001-adopt-unified-roadmap-and-agent-framework.md
@@ -1,4 +1,4 @@
-# 0001 — Adopt a single reconciled roadmap and the Claude Code framework as SSOT
+# 0001 — Adopt a single reconciled roadmap and the agent development framework as SSOT
 
 - Status: Accepted
 - Date: 2026-06-14
@@ -35,7 +35,7 @@ truth.
 ### Consequences
 
 - Good: one roadmap; phased single-PR delivery; ADR-driven decisions; the
-  Claude orchestration model is part of the framework.
+  agent orchestration model is part of the framework.
 - Good: every epic task is traced to a phase in the roadmap's disposition table.
 - Cost: existing epic PRs (#107–#114) must be re-aligned to the phase model.
 - Follow-ups: #115 closed as duplicate; #116 retains its Phase 0 work; #106

--- a/docs/adr/0001-adopt-unified-roadmap-and-claude-framework.md
+++ b/docs/adr/0001-adopt-unified-roadmap-and-claude-framework.md
@@ -1,0 +1,47 @@
+# 0001 — Adopt a single reconciled roadmap and the Claude Code framework as SSOT
+
+- Status: Accepted
+- Date: 2026-06-14
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+The repository was being modernized along two parallel, overlapping plans:
+Track A, the epic-based *"plan de modernisation"* (issue #106, epics #98–#105),
+and Track B, the *"Claude Code framework roadmap"* (PRs #115/#116). They
+targeted the same outcomes but disagreed on structure and tooling, and neither
+was authoritative — so the roadmap was not clear, the process not validated, and
+there was no single source of truth.
+
+## Decision drivers
+
+- One authority, so contributors (human or AI) know where to look.
+- Keep the relevant work from both plans; discard neither.
+- A delivery model that yields focused, reviewable changes.
+- Discipline that survives context loss.
+
+## Considered options
+
+- Keep Track A (epics + sprints) as the spine, graft the framework in as one epic.
+- Keep Track B (phases) as the spine, fold the epics in as phase content.
+- Write a brand-new roadmap merging both numbering schemes from scratch.
+
+## Decision outcome
+
+Chosen option: **Track B phased backbone, with the epics folded in as phase
+content**, captured in [`docs/roadmap.md`](../roadmap.md) as the single source of
+truth.
+
+### Consequences
+
+- Good: one roadmap; phased single-PR delivery; ADR-driven decisions; the
+  Claude orchestration model is part of the framework.
+- Good: every epic task is traced to a phase in the roadmap's disposition table.
+- Cost: existing epic PRs (#107–#114) must be re-aligned to the phase model.
+- Follow-ups: #115 closed as duplicate; #116 retains its Phase 0 work; #106
+  repointed to `docs/roadmap.md`.
+
+## More information
+
+Supersedes the standalone `docs/claude-framework-roadmap.md` from #116 and the
+plan in issue #106.

--- a/docs/adr/0002-contribution-and-release-workflow.md
+++ b/docs/adr/0002-contribution-and-release-workflow.md
@@ -1,0 +1,54 @@
+# 0002 — Contribution & release workflow
+
+- Status: Accepted
+- Date: 2026-06-14
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+Releases were manual, commit history had no enforced convention, and two
+dependency bots (Dependabot + Renovate) produced overlapping PRs. We want an
+automated, predictable contribution-to-release flow.
+
+## Decision drivers
+
+- Automated, changelog-driven releases with minimal manual steps.
+- A commit convention machines can parse (for versioning and changelogs).
+- A single dependency bot to avoid duplicate/conflicting PRs.
+- Low friction for a low-traffic OSS project.
+
+## Considered options
+
+- Release tool: **release-please** vs **Semantic Release**.
+- Merge strategy: squash vs merge-commit vs rebase.
+- Dependency bot: Renovate only vs Dependabot only vs both.
+
+## Decision outcome
+
+Adopted as one interlocking workflow:
+
+- **Conventional Commits**, strict from day one, enforced by `commitlint` on
+  **both** each commit and the **PR title**.
+- **Squash-merge** (one PR = one commit on `master`); the PR title becomes the
+  squash subject and feeds the changelog.
+- **release-please** drives versioning, changelog and GitHub releases via a
+  Release PR; `release.yml` triggers on Release-PR merge. The manual release
+  flow is removed.
+- Optional opt-in local `.githooks/commit-msg` running commitlint in Docker.
+- **Renovate only**; `.github/dependabot.yml` is retired.
+
+release-please was chosen over Semantic Release because its Release-PR model
+pairs naturally with squash-merge (the PR title is the unit of change) and keeps
+release state reviewable in a PR.
+
+### Consequences
+
+- Good: hands-off releases; consistent history; one bot.
+- Cost: contributors must learn Conventional Commits; the in-flight
+  Semantic Release work (PR #107) is reworked to release-please.
+- Follow-ups: roadmap Phase 1; Renovate extension tracked with #102/#20;
+  Dependabot PRs #93–#97 close once Renovate covers their scope.
+
+## More information
+
+Tag strategy is decided separately in ADR-0003.

--- a/docs/adr/0003-image-versioning-and-tag-strategy.md
+++ b/docs/adr/0003-image-versioning-and-tag-strategy.md
@@ -1,0 +1,50 @@
+# 0003 — Image versioning and Docker tag strategy
+
+- Status: Accepted
+- Date: 2026-06-14
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+The image bundles two independently-versioned tools (Terraform, AWS CLI) on a
+Debian base. Consumers need both **reproducible pins** and **convenient floating
+aliases**, and the project needs its own version line decoupled from the bundled
+tools.
+
+## Decision drivers
+
+- Reproducibility: a tag that never changes meaning.
+- Convenience: floating tags so users can track a minor line.
+- A project version independent of Terraform/AWS CLI versions.
+- Alignment with release-please semver (ADR-0002).
+
+## Considered options
+
+- Fully-pinned tags only (`vX.Y.Z_tf-A.B.C_aws-D.E.F`) + `latest`.
+- Floating aliases only (`latest`, `vX.Y`).
+- Both: floating aliases **and** immutable fully-pinned tags.
+
+## Decision outcome
+
+Chosen option: **both**. The image carries:
+
+- `latest` — latest supported versions, from `master`.
+- `edge` — bleeding edge / pre-release builds.
+- `vX.Y.Z` and `vX.Y` — project semver (floating minor), resolving to the latest
+  bundled tool versions for that line.
+- `vX.Y.Z_tf-A.B.C_aws-D.E.F` — **immutable, fully-pinned** combination.
+
+Repo versioning is project semver `vX.Y.Z`; image tags are derived from it.
+
+### Consequences
+
+- Good: reproducible pins for CI; floating tags for humans.
+- Cost: more tags to publish and document.
+- Policy: immutable full tags are **never** mutated; rollback = consumers
+  re-pin an older tag (see `docs/rollback.md`, roadmap Phase 1).
+- Follows: replaces the old `release-S.T_terraform-…_awscli-…` scheme; supersedes
+  the pinned-only proposal in epic #100.
+
+## More information
+
+Roadmap Phase 1 (P0 subset) and Phase 3 (full strategy + GHCR).

--- a/docs/adr/0004-deprecate-terraform-below-1.0.md
+++ b/docs/adr/0004-deprecate-terraform-below-1.0.md
@@ -1,0 +1,42 @@
+# 0004 — Deprecate Terraform versions below 1.0
+
+- Status: Accepted
+- Date: 2026-06-14
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+`supported_versions.json` still lists Terraform 0.11–0.15. These are long EOL,
+require maintaining matching signature material in `security/`, and expand the
+build matrix for versions virtually no one should still run.
+
+## Decision drivers
+
+- Reduce maintenance surface (build matrix, `security/` files).
+- Encourage users onto supported, secure Terraform.
+- Keep the supported set meaningful.
+
+## Considered options
+
+- Keep all versions from 0.11 (status quo, per the old upgrade doc).
+- Drop everything below 1.0.
+- Drop everything below the latest two minor lines.
+
+## Decision outcome
+
+Chosen option: **drop all Terraform versions `< 1.0`** from
+`supported_versions.json` (and their `security/` artifacts). Recent lines
+(1.7.x → 1.11.x) are added in roadmap Phase 3.
+
+### Consequences
+
+- Good: smaller matrix, fewer signature files, clearer support promise.
+- Bad: users pinned to pre-1.0 tags must use an older immutable image tag
+  (which remain available — they are immutable, ADR-0003).
+- Follow-ups: roadmap Phase 1 (cleanup) + Phase 3 (add recent versions);
+  `validate-supported-versions` check (Phase 5/6) guards JSON ↔ `security/`.
+
+## More information
+
+Pre-1.0 images already published remain pullable; this only changes which
+versions are actively built going forward.

--- a/docs/adr/0005-use-madr-format-for-adrs.md
+++ b/docs/adr/0005-use-madr-format-for-adrs.md
@@ -1,0 +1,41 @@
+# 0005 — Use the MADR format for ADRs
+
+- Status: Accepted
+- Date: 2026-06-14
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+We are adopting ADRs (this directory) to record decisions. A consistent,
+lightweight template is needed so ADRs are quick to write and easy to read —
+including by AI agents scaffolding them via a skill.
+
+## Decision drivers
+
+- Low ceremony (low-traffic OSS project).
+- Structured enough for machine scaffolding (`propose-adr` skill).
+- Widely recognised.
+
+## Considered options
+
+- **MADR** (Markdown Any Decision Records).
+- **Nygard**'s original lightweight format.
+- A bespoke template.
+
+## Decision outcome
+
+Chosen option: **MADR**, see [`0000-template.md`](0000-template.md). Nygard was
+considered but MADR's explicit "decision drivers / considered options /
+consequences" sections suit machine scaffolding better, at acceptable extra
+ceremony.
+
+### Consequences
+
+- Good: uniform structure; skill-friendly; familiar to contributors.
+- Cost: slightly more sections than Nygard.
+- Note: this ADR is itself written in the format it adopts; ADR-0001–0004 in the
+  same batch follow it.
+
+## More information
+
+https://adr.github.io/madr/

--- a/docs/adr/0006-agent-orchestration-strategy.md
+++ b/docs/adr/0006-agent-orchestration-strategy.md
@@ -6,8 +6,8 @@
 
 ## Context and problem statement
 
-The roadmap described the Claude orchestration as prose ("Opus orchestrates,
-Sonnet executes") with model names hard-coded into the narrative. Model names
+The roadmap described the agent orchestration as prose (naming specific models
+as orchestrator/executor) with model names hard-coded into the narrative. Model names
 drift, and a per-repo prose strategy is not portable to other repositories. We
 want the strategy to be generic, configurable, and a single source of truth.
 
@@ -55,7 +55,7 @@ Chosen option: **role/tier abstraction, config-driven**.
 - Good: portable, drift-free, one-edit model swaps; consistent with SSOT rule.
 - Cost: one indirection (role → model) to learn.
 - Follow-ups: implemented in roadmap Phase 2 (`.claude/settings.json`,
-  `docs/claude-framework.md`) and Phase 6 (subagents reference roles).
+  `docs/agent-framework.md`) and Phase 6 (subagents reference roles).
 
 ## More information
 

--- a/docs/adr/0006-agent-orchestration-strategy.md
+++ b/docs/adr/0006-agent-orchestration-strategy.md
@@ -30,8 +30,8 @@ Chosen option: **role/tier abstraction, config-driven**.
 
 - Define **roles**, not models: `orchestrator`, `executor`, optional `reviewer`.
 - Subagents and docs reference a **role**; never a concrete model name.
-- A **single mapping** lives in `.claude/settings.json` (created in roadmap
-  Phase 2):
+- A **single mapping** lives in the active tool's adapter (`.claude/settings.json`
+  for Claude Code; see ADR-0009), created in roadmap Phase 2:
 
   ```jsonc
   // illustrative shape — authoritative version lands in Phase 2

--- a/docs/adr/0006-agent-orchestration-strategy.md
+++ b/docs/adr/0006-agent-orchestration-strategy.md
@@ -1,0 +1,64 @@
+# 0006 — Generic, config-driven agent orchestration strategy
+
+- Status: Accepted
+- Date: 2026-06-14
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+The roadmap described the Claude orchestration as prose ("Opus orchestrates,
+Sonnet executes") with model names hard-coded into the narrative. Model names
+drift, and a per-repo prose strategy is not portable to other repositories. We
+want the strategy to be generic, configurable, and a single source of truth.
+
+## Decision drivers
+
+- Model IDs change; embedding them in prose causes drift (violates the
+  "reference, don't embed" SSOT rule).
+- The orchestration core should be portable / template-able across repos.
+- Swapping a model should be a one-line change, not a doc-wide edit.
+
+## Considered options
+
+- Keep prose with named models (status quo).
+- Hard-code models in each subagent definition.
+- **Role/tier abstraction** with a single tier→model mapping in config.
+
+## Decision outcome
+
+Chosen option: **role/tier abstraction, config-driven**.
+
+- Define **roles**, not models: `orchestrator`, `executor`, optional `reviewer`.
+- Subagents and docs reference a **role**; never a concrete model name.
+- A **single mapping** lives in `.claude/settings.json` (created in roadmap
+  Phase 2):
+
+  ```jsonc
+  // illustrative shape — authoritative version lands in Phase 2
+  {
+    "agentRoles": {
+      "orchestrator": { "model": "<current-flagship>", "purpose": "planning, review-before-push, ADR drafting, structural decisions" },
+      "executor":     { "model": "<current-workhorse>", "purpose": "scoped implementation, refactors, docs" },
+      "reviewer":     { "model": "<current-workhorse>", "purpose": "diff review, security/lint passes" }
+    }
+  }
+  ```
+
+- Swapping a model = edit one value. Docs cite the role; the config holds the
+  current model.
+- **Generic core vs repo specifics:** the orchestration core (roles, mapping,
+  hard rules, session hook) is portable to any repo; repo-specific skills
+  (`bump-terraform-version`, etc.) stay separate.
+
+### Consequences
+
+- Good: portable, drift-free, one-edit model swaps; consistent with SSOT rule.
+- Cost: one indirection (role → model) to learn.
+- Follow-ups: implemented in roadmap Phase 2 (`.claude/settings.json`,
+  `docs/claude-framework.md`) and Phase 6 (subagents reference roles).
+
+## More information
+
+The hard rules (authorization, branching, commits, delegation review) in
+`docs/roadmap.md` remain the binding conventions; this ADR only genericises the
+model/role mapping.

--- a/docs/adr/0007-adopt-entire-checkpoints.md
+++ b/docs/adr/0007-adopt-entire-checkpoints.md
@@ -61,5 +61,5 @@ Session transcripts live on a separate `entire/checkpoints/v1` branch, not on
 ## More information
 
 - https://entire.io · https://github.com/entireio/cli
-- Sequence with roadmap Phase 2 (Claude foundations) so `.claude/settings.json`
+- Sequence with roadmap Phase 2 (Agent foundations) so `.claude/settings.json`
   is authored once, consistently with ADR-0006.

--- a/docs/adr/0007-adopt-entire-checkpoints.md
+++ b/docs/adr/0007-adopt-entire-checkpoints.md
@@ -1,0 +1,65 @@
+# 0007 — Adopt Entire / Checkpoints for agent-session capture
+
+- Status: Proposed
+- Date: 2026-06-14
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+This repository is developed heavily with AI agents. We want a durable,
+searchable record of *how* changes were produced (prompts, reasoning, file
+changes) linked to Git history, complementing the ADRs that record *why*.
+[Entire](https://entire.io) (by Thomas Dohmke, ex-GitHub CEO) ships an OSS CLI,
+`entire` / Checkpoints, that captures agent sessions alongside commits and
+supports Claude Code.
+
+## Decision drivers
+
+- Capture agent context that today is lost when a session ends.
+- First-class Claude Code support.
+- Keep the main branch clean (session data stored out-of-band).
+
+## Considered options
+
+- **Adopt Entire / Checkpoints.**
+- Rely only on commit trailers + ADRs (status quo).
+- A community checkpoint tool (e.g. `ccheckpoints`).
+
+## Decision outcome
+
+Chosen option: **adopt Entire / Checkpoints**, but **scaffold now, activate
+locally**. It is complementary to ADRs (Checkpoints = *how*, ADRs = *why*), not a
+replacement.
+
+What is committed now (this change):
+- `.gitignore` entries for `.entire/settings.local.json` and
+  `.claude/settings.local.json`.
+- `docs/entire-setup.md` with the activation steps.
+- This ADR (status **Proposed** until activation lands).
+
+What the maintainer runs locally (cannot be done from a headless CI/agent
+environment because `entire login` is an interactive device-auth flow):
+
+```bash
+brew install --cask entire      # or: curl -fsSL https://entire.io/install.sh | bash
+entire login                    # interactive device auth
+entire enable --agent claude-code
+```
+
+Then commit the generated `.entire/settings.json` and `.claude/settings.json`.
+Session transcripts live on a separate `entire/checkpoints/v1` branch, not on
+`master`.
+
+### Consequences
+
+- Good: durable, searchable agent-session history linked to commits.
+- Risk: early-stage product; account/auth dependency; `.claude/settings.json`
+  overlaps with roadmap Phase 2 — sequence the two together.
+- Bad: cannot be fully automated from CI (interactive login).
+- Status flips to **Accepted** once activation is committed.
+
+## More information
+
+- https://entire.io · https://github.com/entireio/cli
+- Sequence with roadmap Phase 2 (Claude foundations) so `.claude/settings.json`
+  is authored once, consistently with ADR-0006.

--- a/docs/adr/0008-conventional-branch-naming.md
+++ b/docs/adr/0008-conventional-branch-naming.md
@@ -1,0 +1,51 @@
+# 0008 — Conventional branch naming
+
+- Status: Accepted
+- Date: 2026-06-14
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+The original framework convention named branches `claude/phase-N-<topic>`. That
+embeds a tool name ("claude") into shared Git history and does not align with the
+Conventional Commits vocabulary we already enforce on commits and PR titles
+(ADR-0002). We want branch names that are tool-agnostic and consistent with that
+vocabulary.
+
+## Decision drivers
+
+- Tool-agnostic naming (no "claude" / agent names in shared refs).
+- Consistency with Conventional Commits (already enforced elsewhere).
+- Traceability to roadmap phases without rigidity.
+
+## Considered options
+
+- `type/topic` using the Conventional Commits type set, with `type/phase-N-topic`
+  for roadmap phases.
+- `type/NN-topic` always embedding an issue/phase number.
+- GitFlow fixed prefixes (`feature/`, `fix/`, `release/`, `chore/`).
+
+## Decision outcome
+
+Chosen option: **`type/topic`**, with **`type/phase-N-topic`** for roadmap-phase
+branches.
+
+- `type` is one of the Conventional Commits types: `feat`, `fix`, `docs`,
+  `chore`, `ci`, `refactor`, `build`, `test`, `perf`.
+- `topic` is a short kebab-case slug.
+- Examples: `docs/framework-foundation`, `ci/pr-triggers`,
+  `chore/bump-terraform`, `docs/phase-1-oss-governance`.
+
+This replaces hard-rule #7's `claude/phase-N-<topic>` in
+[`docs/roadmap.md`](../roadmap.md).
+
+### Consequences
+
+- Good: tool-agnostic, consistent with commit/PR conventions, still phase-aware.
+- Cost: none material; one rule updated.
+- Follow-ups: roadmap hard-rule #7 updated; Decisions table records this ADR.
+
+## More information
+
+Aligns with ADR-0002 (Conventional Commits). No automated branch-name linting is
+added for now; the convention is documented and reviewed.

--- a/docs/adr/0009-agent-agnostic-framework.md
+++ b/docs/adr/0009-agent-agnostic-framework.md
@@ -1,0 +1,65 @@
+# 0009 — Agent-agnostic framework with a tool-specific adapter layer
+
+- Status: Accepted
+- Date: 2026-06-14
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+The framework was authored around "Claude" — naming ("Claude Code framework",
+"Claude foundations"), planned files (`docs/claude-framework.md`,
+`scripts/claude-session-start.sh`), and hard-coded model names (Opus/Sonnet) in
+prose. That couples the framework to one agent and contradicts ADR-0006 (generic
+role/tier orchestration) and ADR-0008 (no tool names in shared refs). At the same
+time, some artifacts are **mandated by the Claude Code tool** and cannot be
+renamed without breaking it.
+
+## Decision drivers
+
+- Portability: the framework should not be tied to a single agent.
+- Consistency with ADR-0006 (roles, not model names) and ADR-0008.
+- Pragmatism: Claude Code is the agent actually in use; its required files must
+  keep their names to function.
+
+## Considered options
+
+- Leave everything Claude-named (status quo).
+- Rename everything to be agnostic (breaks the Claude Code tool, which requires
+  `.claude/` and `CLAUDE.md`).
+- **Two layers: an agnostic core + a thin tool-specific adapter.**
+
+## Decision outcome
+
+Chosen option: **two layers**.
+
+**Agnostic core** (no tool names; portable to any agent):
+- SSOT instructions: `AGENTS.md` at repo root.
+- Docs: `docs/agent-framework.md`, `docs/agent-conventions.md`, `docs/roadmap.md`.
+- Orchestration by **role/tier** (`orchestrator`/`executor`/`reviewer`),
+  ADR-0006 — never model names in prose.
+- Generic skill *logic* and conventions.
+
+**Tool adapter layer** (Claude Code specifics, clearly labelled as adapter):
+- `.claude/` (settings, skills, subagents) and a thin `CLAUDE.md` that points to
+  `AGENTS.md`. Claude Code reads these by name, so they keep their names.
+- The role→model mapping lives in `.claude/settings.json` (the adapter holds the
+  concrete models).
+- Another agent (e.g. Gemini CLI) would add its own adapter (e.g. `GEMINI.md`)
+  without touching the core.
+
+Legitimate tool references (e.g. `entire enable --agent claude-code`, "Claude
+Code support" in ADR-0007) remain — they name a real tool, not the framework.
+
+### Consequences
+
+- Good: portable framework; consistent with ADR-0006/0008; one place per tool.
+- Cost: a thin `CLAUDE.md` adapter duplicating a pointer to `AGENTS.md`.
+- Follow-ups: implemented in roadmap Phase 2 (now "Agent foundations"); existing
+  docs/ADRs reworded in this change.
+
+## More information
+
+`.claude/` cannot be renamed while Claude Code is the active agent — that is the
+reason an adapter layer exists rather than full renaming. Historical references
+to the former `claude-framework-roadmap.md` (the superseded Track B file) are
+kept as-is for traceability.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,59 @@
+# Architecture Decision Records (ADRs)
+
+This directory holds the **Architecture Decision Records** for
+`terraform-aws-cli`. An ADR captures a single significant decision — its
+context, the options considered, the choice, and its consequences — so the
+*why* behind the repository survives context loss (for humans and AI agents
+alike).
+
+## When an ADR is required
+
+Any **structural change** must be accompanied by an ADR. As a rule of thumb, a
+change is structural if it touches one of these and alters behaviour or policy:
+
+- `Dockerfile` (stages, base image policy, build approach)
+- `.github/workflows/**` (CI/CD topology, release flow, security gates)
+- `supported_versions.json` (version-support policy)
+- release / commit / dependency-bot configuration
+- the Claude framework (`.claude/**`, orchestration strategy, skills/agents)
+
+A pure version bump, a typo fix, or a docs tweak does **not** need an ADR.
+
+## How it is enforced
+
+1. **PR template checkbox** — every PR declares "ADR added" or "not structural".
+2. **CI gate** — `.github/workflows/adr-check.yml` fails a PR that touches
+   structural paths (or carries the `needs-adr` label) without adding a new
+   `docs/adr/NNNN-*.md`. Apply the `adr-not-needed` label to bypass with a
+   reviewer's blessing.
+3. **CODEOWNERS** — changes under `docs/adr/` and structural paths require
+   review.
+
+This is strong enforcement, not a mathematical guarantee: "structural" can't be
+perfectly auto-detected, so the path heuristic + checkbox + human review is the
+realistic ceiling.
+
+## Format
+
+ADRs use the [MADR](https://adr.github.io/madr/) format — see
+[`0005-use-madr-format-for-adrs.md`](0005-use-madr-format-for-adrs.md) and the
+[`0000-template.md`](0000-template.md).
+
+## Creating one
+
+Copy the template, take the next free number, fill it in, and reference it from
+the [roadmap](../roadmap.md) Decisions table. The `propose-adr` skill (roadmap
+Phase 6) will scaffold this automatically.
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-adopt-unified-roadmap-and-claude-framework.md) | Adopt a single reconciled roadmap and the Claude Code framework as SSOT | Accepted |
+| [0002](0002-contribution-and-release-workflow.md) | Contribution & release workflow (Conventional Commits, squash, release-please, Renovate) | Accepted |
+| [0003](0003-image-versioning-and-tag-strategy.md) | Image versioning and Docker tag strategy | Accepted |
+| [0004](0004-deprecate-terraform-below-1.0.md) | Deprecate Terraform versions below 1.0 | Accepted |
+| [0005](0005-use-madr-format-for-adrs.md) | Use the MADR format for ADRs | Accepted |
+| [0006](0006-agent-orchestration-strategy.md) | Generic, config-driven agent orchestration strategy | Accepted |
+| [0007](0007-adopt-entire-checkpoints.md) | Adopt Entire / Checkpoints for agent-session capture | Proposed |
+| [0008](0008-conventional-branch-naming.md) | Conventional branch naming | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,7 +15,7 @@ change is structural if it touches one of these and alters behaviour or policy:
 - `.github/workflows/**` (CI/CD topology, release flow, security gates)
 - `supported_versions.json` (version-support policy)
 - release / commit / dependency-bot configuration
-- the Claude framework (`.claude/**`, orchestration strategy, skills/agents)
+- the agent framework (`.claude/**` adapter, orchestration strategy, skills/agents)
 
 A pure version bump, a typo fix, or a docs tweak does **not** need an ADR.
 
@@ -49,7 +49,7 @@ Phase 6) will scaffold this automatically.
 
 | ADR | Title | Status |
 |---|---|---|
-| [0001](0001-adopt-unified-roadmap-and-claude-framework.md) | Adopt a single reconciled roadmap and the Claude Code framework as SSOT | Accepted |
+| [0001](0001-adopt-unified-roadmap-and-agent-framework.md) | Adopt a single reconciled roadmap and the agent development framework as SSOT | Accepted |
 | [0002](0002-contribution-and-release-workflow.md) | Contribution & release workflow (Conventional Commits, squash, release-please, Renovate) | Accepted |
 | [0003](0003-image-versioning-and-tag-strategy.md) | Image versioning and Docker tag strategy | Accepted |
 | [0004](0004-deprecate-terraform-below-1.0.md) | Deprecate Terraform versions below 1.0 | Accepted |
@@ -57,3 +57,4 @@ Phase 6) will scaffold this automatically.
 | [0006](0006-agent-orchestration-strategy.md) | Generic, config-driven agent orchestration strategy | Accepted |
 | [0007](0007-adopt-entire-checkpoints.md) | Adopt Entire / Checkpoints for agent-session capture | Proposed |
 | [0008](0008-conventional-branch-naming.md) | Conventional branch naming | Accepted |
+| [0009](0009-agent-agnostic-framework.md) | Agent-agnostic framework with a tool-specific adapter layer | Accepted |

--- a/docs/entire-setup.md
+++ b/docs/entire-setup.md
@@ -1,0 +1,48 @@
+# Entire / Checkpoints — setup
+
+[Entire](https://entire.io) captures AI-agent sessions (prompts, reasoning, file
+changes) alongside Git history. It complements our ADRs: Checkpoints records
+*how* a change was produced, ADRs record *why*. Decision: see
+[ADR-0007](adr/0007-adopt-entire-checkpoints.md).
+
+## Why this is a local, maintainer-run step
+
+`entire login` is an **interactive device-auth flow** (Anthropic auth) and the
+CLI is a binary that must be installed — neither can be done from a headless
+CI/agent environment. The repository ships the surrounding scaffold; activation
+is one local pass.
+
+## Activation (run locally, once)
+
+```bash
+# 1. Install the CLI
+brew install --cask entire
+# or: curl -fsSL https://entire.io/install.sh | bash
+
+# 2. Authenticate (interactive)
+entire login
+
+# 3. Enable for Claude Code (bootstraps config on an unconfigured repo)
+entire enable --agent claude-code
+```
+
+This generates:
+
+- `.entire/settings.json` — project config (**commit this**)
+- `.claude/settings.json` — Claude Code hooks (**commit this**; reconcile with
+  the Phase 2 `.claude/settings.json` per ADR-0006)
+- `.entire/settings.local.json`, `.claude/settings.local.json` — personal
+  overrides (**git-ignored**, already in `.gitignore`)
+
+Session transcripts are stored on a separate `entire/checkpoints/v1` branch, not
+on `master`. Push it to the same remote (or a dedicated checkpoints repo) with:
+
+```bash
+entire configure --checkpoint-remote github:bgauduch/terraform-aws-cli
+```
+
+## After activation
+
+Commit the generated `.entire/settings.json` and `.claude/settings.json`, then
+flip [ADR-0007](adr/0007-adopt-entire-checkpoints.md) status from **Proposed** to
+**Accepted**.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -223,6 +223,15 @@ Subagents & slash commands:
 - Additional tag aliases if demand emerges (`terraform-A.B.C`, `terraform-A.B`)
 - Re-evaluate the multi-agent panel after 3 months of usage
 
+### Phase 8 — Default branch rename `master` → `main` *(P2, not top priority)*
+Low-priority hygiene; cross-cutting, so delivered as its own phase.
+- Rename the default branch `master` → `main` (GitHub UI)
+- Update workflow refs across `.github/workflows/**` (`branches: [master]`, `!master`, base-branch assumptions)
+- Re-point branch protection + squash/auto-delete settings to `main`
+- Update docs that hard-code `master` (this roadmap's hard rules, README badges/links, ADRs, `dev.sh` if needed)
+- Update external links pointing at `master` (Docker Hub description, badges)
+- Record the rename in an ADR when executed
+
 ---
 
 ## Open PR & issue disposition
@@ -231,7 +240,7 @@ How the existing work is preserved or retired under the reconciled plan.
 
 | Item | Disposition |
 |---|---|
-| PR #116 *(Phase 0)* | Keep — replace its `claude-framework-roadmap.md` with this `docs/roadmap.md`; retain the workflow path fixes |
+| PR #116 *(Phase 0)* | **Closed** — superseded by #119, which carries the workflow path fixes + deps-doc refresh without the obsolete roadmap doc |
 | PR #115 *(roadmap doc only)* | **Close** — duplicate, superseded by this document |
 | PR #107 *(semantic-release)* | Rework into Phase 1 with **release-please**; salvage the commitlint parts |
 | PR #109 *(renovate)* | Fold into Phase 1; ensure Dependabot retirement |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap — terraform-aws-cli
 
-> **Single source of truth** for the modernization and the Claude Code framework
+> **Single source of truth** for the modernization and the agent development framework
 > of this repository. This document reconciles and supersedes the two former
 > plans:
 >
@@ -38,10 +38,11 @@ upstream is no longer maintained).
 
 ## Orchestration & development conventions (hard rules)
 
-These rules bind any Claude session, sub-agent, or human contributor. They apply
+These rules bind any agent session, sub-agent, or human contributor. They apply
 **now**, even before the framework phases land. They are the source of truth
-until extracted to `docs/claude-framework-conventions.md` (Phase 2) and reflected
-in `CLAUDE.md` (Phase 2).
+until extracted to `docs/agent-conventions.md` (Phase 2) and reflected in the
+agent instructions file (`AGENTS.md`, with a thin `CLAUDE.md` adapter for Claude
+Code) (Phase 2).
 
 ### Authorization (irreversible / shared-state actions)
 1. **NEVER merge a pull request without explicit human approval.** Even with
@@ -49,7 +50,7 @@ in `CLAUDE.md` (Phase 2).
 2. **NEVER push to `master` directly.** All changes flow through a phase branch
    and a pull request.
 3. **NEVER create a pull request without an explicit request from the user.**
-   Claude commits, pushes, then reports — the user decides when to open the PR.
+   The agent commits, pushes, then reports — the user decides when to open the PR.
 4. **NEVER force-push, amend pushed commits, or rewrite shared history.** Always
    add a new commit on top.
 5. **NEVER bypass hooks** (no `--no-verify`, no `--no-gpg-sign`). A failing hook
@@ -70,17 +71,21 @@ in `CLAUDE.md` (Phase 2).
    Phase 1 lands). The PR title matters because the squash-merge subject feeds
    the release-please changelog.
 10. One commit per logical change for reviewability. Avoid mega-commits.
-11. Every commit body ends with the session trailer when produced in a Claude
+11. Every commit body ends with the session trailer when produced in an agent
     session.
 
-### Model and delegation (orchestration)
-12. **Opus is the orchestrator:** planning, briefs, diff review before push,
+### Roles and delegation (orchestration)
+12. **The `orchestrator` role** owns planning, briefs, diff review before push,
     structural decisions, ADR drafting.
-13. **Sonnet executes scoped briefs:** implementation, refactors, docs.
-14. Every Sonnet delegation **must** be reviewed by Opus
+13. **The `executor` role** runs scoped briefs: implementation, refactors, docs.
+14. Every `executor` delegation **must** be reviewed by the `orchestrator`
     (`git diff master..HEAD`) before push.
 15. Phase briefs are ephemeral (conversation only). They are reconstructable
     from this roadmap + the relevant ADRs, so they are not committed.
+
+> Roles map to concrete models in one place (`.claude/settings.json` for Claude
+> Code) per ADR-0006 — never hard-coded in prose. See ADR-0009 for the
+> agent-agnostic / tool-adapter split.
 
 ### Scope discipline
 16. A phase touches only files within its declared scope. Drift discovered
@@ -108,13 +113,14 @@ in `CLAUDE.md` (Phase 2).
 | Rollback policy | No mutation of immutable full tags; consumers re-pin an older tag | `docs/rollback.md` |
 | ADR enforcement | PR-template checkbox + `adr-check.yml` CI gate + CODEOWNERS (no soft-rule-only) | this doc |
 | Branch naming | `type/topic` (Conventional types), `type/phase-N-topic` for phases; no tool names | ADR-0008 |
+| Agent-agnostic framework | Generic core (agnostic docs + naming, role/tier orchestration); `.claude/` + `CLAUDE.md` are the Claude Code **adapter** layer | ADR-0009 |
 | Agent orchestration | Role/tier abstraction (`orchestrator`/`executor`/`reviewer`), model mapping in `.claude/settings.json` (generic, drift-free) | ADR-0006 |
 | Agent session capture | Adopt Entire / Checkpoints — scaffold now, activate locally | ADR-0007 |
 | Multi-agent plan validation | Single `tech-architect` agent (no 4-agent panel) | — |
 | End-user persona agents | Two on-demand agents: `end-user-sre-ci`, `end-user-dev-local` | — |
 | Supply chain | Trivy scan, SBOM (SPDX), SLSA provenance, cosign signing | — |
-| PostToolUse ADR nudge hook | Deferred (rely on skill description + CLAUDE.md rule + PR checkbox) | — |
-| `audit-claude-framework` skill | Replaced by a monthly CI health-check workflow | — |
+| PostToolUse ADR nudge hook | Deferred (rely on skill description + agent-instructions rule + PR checkbox) | — |
+| `audit-agent-framework` skill | Replaced by a monthly CI health-check workflow | — |
 | MCP custom servers | Out of scope | — |
 
 Superseded plans: issue #106 and PRs #115 (close) / #116 (its Phase 0 work is
@@ -156,13 +162,14 @@ The contribution + release machinery. May split into 1a (governance docs) and
 - `README.md` governance refresh + badges (CI, latest release, GHCR, cosign) *(#105)*
 - ADR-0001 … ADR-0005, `docs/rollback.md`
 
-### Phase 2 — Claude foundations *(P0)* — Track B
-- `CLAUDE.md` at repo root (sources of truth, ADR rule, no hard-coded values)
-- `.claude/README.md` (framework map) + `docs/claude-framework.md` (architecture, walkthrough, token-cost notes)
-- `docs/claude-framework-conventions.md` (extract of the hard rules above)
+### Phase 2 — Agent foundations *(P0)* — Track B
+Agnostic core + a thin Claude Code adapter (ADR-0009).
+- `AGENTS.md` at repo root — agnostic SSOT (sources of truth, ADR rule, no hard-coded values); thin `CLAUDE.md` adapter pointing to it (Claude Code reads `CLAUDE.md`)
+- `docs/agent-framework.md` (architecture, walkthrough, token-cost notes) + `docs/agent-conventions.md` (extract of the hard rules above)
+- `.claude/README.md` (Claude adapter map)
 - `.claude/settings.json` — permissions allowlist **+ the role→model mapping** (`orchestrator`/`executor`/`reviewer`) per ADR-0006; no PostToolUse hook yet
 - `.gitignore`: `.claude/settings.local.json` *(done early)*
-- `scripts/claude-session-start.sh` (SessionStart hook)
+- `scripts/agent-session-start.sh` (SessionStart hook)
 - Reconcile with Entire-generated `.claude/settings.json` if Entire is activated (ADR-0007 / `docs/entire-setup.md`)
 
 ### Phase 3 — Versions & distribution *(P0)* — folds in #98, #100
@@ -194,7 +201,7 @@ Urgent: current versions are frozen at end-2023 and accrue CVEs.
 - Explicit least-privilege `permissions:` on every job *(#99)*
 - `validate-supported-versions.yml` (matrix check `supported_versions.json` ↔ `security/`)
 
-### Phase 6 — Claude skills & subagents *(P1)* — Track B
+### Phase 6 — Agent skills & subagents *(P1)* — Track B
 Skills (auto-discovered via `SKILL.md` descriptions):
 - `bump-terraform-version`, `bump-awscli-version`, `bump-debian-base`
 - `propose-adr`, `validate-supported-versions`
@@ -205,10 +212,10 @@ Subagents & slash commands:
 - Upstream `/plan`: single `tech-architect` agent (poses structural questions, flags `adr_required`); `end-user-sre-ci` and `end-user-dev-local` as on-demand consultative agents
 
 ### Phase 7 — Durability & bonuses *(P2)*
-- Monthly `health-check-claude-framework.yml`
+- Monthly `health-check-agent-framework.yml`
 - `ossf/scorecard-action` (OpenSSF score) *(#105)*
 - `actions/stale` for PRs/issues
-- "Last reviewed" section in `CLAUDE.md`
+- "Last reviewed" section in `AGENTS.md`
 - Multi-arch container-structure-tests (at least `linux/arm64`)
 - Image-size regression guard
 - Integration smoke test (`terraform init`)
@@ -245,10 +252,10 @@ How the existing work is preserved or retired under the reconciled plan.
 ## Explicitly out of scope
 
 - Custom MCP servers
-- `audit-claude-framework` as a Claude skill (replaced by CI)
+- `audit-agent-framework` as an agent skill (replaced by CI)
 - Generic pre-commit framework (Python dependency)
 - Pre-push git hooks (covered by `/preflight` + CI)
-- PostToolUse hook for ADR nudge (unless Claude is observed forgetting in practice)
+- PostToolUse hook for ADR nudge (unless the agent is observed forgetting in practice)
 - Retroactive backfill of ADRs
 - Image variants (alpine, slim)
 - Bundling python3 in the image (revisit #80/#88/#92 only if demand is strong; document the workaround instead)
@@ -261,5 +268,5 @@ How the existing work is preserved or retired under the reconciled plan.
   (Phase 6).
 - Every phase delivery is a single PR; the PR description references the phase
   block above.
-- `CLAUDE.md` and skill files reference sources of truth (JSON files, ADRs)
-  rather than embedding values that drift.
+- Agent instructions (`AGENTS.md`/`CLAUDE.md`) and skill files reference sources
+  of truth (JSON files, ADRs) rather than embedding values that drift.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,265 @@
+# Roadmap — terraform-aws-cli
+
+> **Single source of truth** for the modernization and the Claude Code framework
+> of this repository. This document reconciles and supersedes the two former
+> plans:
+>
+> - Track A — *"Plan de modernisation"* (issue #106 + epics #98–#105)
+> - Track B — *"Claude Code framework roadmap"* (PRs #115 / #116)
+>
+> Last updated: 2026-06-14 · Status: Phase 0 in progress
+>
+> Reconciliation decisions validated 2026-06-14:
+> phases backbone (epics folded in as content) · release-please ·
+> floating + immutable tags · Renovate only (Dependabot retired).
+
+## Why this document exists
+
+The repository was being modernized along two parallel plans that targeted the
+same outcomes but disagreed on structure and tooling. This file merges them into
+one authority so that the **roadmap is clear**, the **process is documented and
+validated**, and the **framework is single-source-of-truth**.
+
+It freezes the agreed plan, survives context loss, and onboards future
+contributors (human or AI). Decisions are summarised in the Decisions table and
+detailed in their ADRs (`docs/adr/`).
+
+## Repository profile
+
+Minimalist Docker image bundling Terraform CLI + AWS CLI on Debian. Low-traffic
+OSS project. Recurring tasks: bumping Terraform / AWS CLI versions, bumping the
+Debian base image, bumping GitHub Actions, cutting releases, reviewing the
+Dockerfile.
+
+Reference repository: `bgauduch/terraform-aws-cli` (the `zenika-open-source`
+upstream is no longer maintained).
+
+---
+
+## Orchestration & development conventions (hard rules)
+
+These rules bind any Claude session, sub-agent, or human contributor. They apply
+**now**, even before the framework phases land. They are the source of truth
+until extracted to `docs/claude-framework-conventions.md` (Phase 2) and reflected
+in `CLAUDE.md` (Phase 2).
+
+### Authorization (irreversible / shared-state actions)
+1. **NEVER merge a pull request without explicit human approval.** Even with
+   green CI and positive reviews, only the human triggers a merge.
+2. **NEVER push to `master` directly.** All changes flow through a phase branch
+   and a pull request.
+3. **NEVER create a pull request without an explicit request from the user.**
+   Claude commits, pushes, then reports — the user decides when to open the PR.
+4. **NEVER force-push, amend pushed commits, or rewrite shared history.** Always
+   add a new commit on top.
+5. **NEVER bypass hooks** (no `--no-verify`, no `--no-gpg-sign`). A failing hook
+   is a signal — fix the cause.
+6. **NEVER delete a branch, tag, or remote ref without explicit approval.**
+
+### Branching & delivery
+7. One branch per phase, named `type/phase-N-<topic>` (Conventional-Commits type,
+   kebab-case topic), off `master`. Non-phase work uses `type/<topic>`. No tool
+   or agent names in branch names. See ADR-0008.
+8. One pull request per phase. A phase may be split into a small number of
+   sequential PRs **only** if a single PR would be too large to review — they
+   stay strictly within the phase scope.
+
+### Commits
+9. Conventional Commits (`type(scope): subject`) for **both** commit messages
+   **and** PR titles. Strict from day one (enforced by `commitlint.yml` once
+   Phase 1 lands). The PR title matters because the squash-merge subject feeds
+   the release-please changelog.
+10. One commit per logical change for reviewability. Avoid mega-commits.
+11. Every commit body ends with the session trailer when produced in a Claude
+    session.
+
+### Model and delegation (orchestration)
+12. **Opus is the orchestrator:** planning, briefs, diff review before push,
+    structural decisions, ADR drafting.
+13. **Sonnet executes scoped briefs:** implementation, refactors, docs.
+14. Every Sonnet delegation **must** be reviewed by Opus
+    (`git diff master..HEAD`) before push.
+15. Phase briefs are ephemeral (conversation only). They are reconstructable
+    from this roadmap + the relevant ADRs, so they are not committed.
+
+### Scope discipline
+16. A phase touches only files within its declared scope. Drift discovered
+    mid-phase is captured as a follow-up (TODO in the PR description or a new
+    ADR) — not silently included.
+17. Out-of-scope items are not added back without a decision update (a new entry
+    in the Decisions table and, if structural, an ADR).
+
+---
+
+## Decisions
+
+| Topic | Decision | ADR |
+|---|---|---|
+| Roadmap structure | Phases backbone; the former epics #98–#105 are folded in as phase content | this doc |
+| Image versioning | Repo semver `vX.Y.Z`; image tags derived | ADR-0003 |
+| Tag strategy | Floating `latest`, `edge`, `vX.Y.Z`, `vX.Y` **+** fully-pinned immutable `vX.Y.Z_tf-A.B.C_aws-D.E.F` | ADR-0003 |
+| Commit convention | Conventional Commits, **strict** from day one (commit history **and** PR titles) | ADR-0002 |
+| Merge strategy | **Squash-merge** (one PR = one commit on `master`); PR title becomes the squash subject and feeds the changelog | ADR-0002 |
+| Release automation | **release-please** (Google), Release-PR workflow | ADR-0002 |
+| Local commit-msg hook | Standalone `.githooks/commit-msg` running commitlint in Docker, opt-in | ADR-0002 |
+| Dependency bot | **Renovate only** (Dependabot retired) | ADR-0002 |
+| ADR format | MADR (Nygard considered, rejected for simplicity) | ADR-0005 |
+| Terraform deprecation | Drop versions `< 1.0` from `supported_versions.json` | ADR-0004 |
+| Rollback policy | No mutation of immutable full tags; consumers re-pin an older tag | `docs/rollback.md` |
+| ADR enforcement | PR-template checkbox + `adr-check.yml` CI gate + CODEOWNERS (no soft-rule-only) | this doc |
+| Branch naming | `type/topic` (Conventional types), `type/phase-N-topic` for phases; no tool names | ADR-0008 |
+| Agent orchestration | Role/tier abstraction (`orchestrator`/`executor`/`reviewer`), model mapping in `.claude/settings.json` (generic, drift-free) | ADR-0006 |
+| Agent session capture | Adopt Entire / Checkpoints — scaffold now, activate locally | ADR-0007 |
+| Multi-agent plan validation | Single `tech-architect` agent (no 4-agent panel) | — |
+| End-user persona agents | Two on-demand agents: `end-user-sre-ci`, `end-user-dev-local` | — |
+| Supply chain | Trivy scan, SBOM (SPDX), SLSA provenance, cosign signing | — |
+| PostToolUse ADR nudge hook | Deferred (rely on skill description + CLAUDE.md rule + PR checkbox) | — |
+| `audit-claude-framework` skill | Replaced by a monthly CI health-check workflow | — |
+| MCP custom servers | Out of scope | — |
+
+Superseded plans: issue #106 and PRs #115 (close) / #116 (its Phase 0 work is
+retained, its roadmap doc is replaced by this file).
+
+> **Brought forward (delivered ahead of Phase 1):** the ADR system now exists at
+> `docs/adr/` (ADR-0001…0007) capturing every decision above, together with its
+> enforcement (`.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/adr-check.yml`,
+> `.github/CODEOWNERS`). The Entire scaffold (`docs/entire-setup.md`, `.gitignore`)
+> is also in place; activation is a local maintainer step (ADR-0007).
+
+---
+
+## Phases
+
+Each phase is delivered as **one pull request** (occasionally split per rule 8)
+to enable focused review. The "Folds in" column traces each former epic to its
+new home.
+
+### Phase 0 — Cleanup *(P0, in progress — PR #116)*
+Pure hygiene, no new tooling.
+- This roadmap document (replaces the former `claude-framework-roadmap.md`)
+- Fix `push-latest.yml` (`supported_platforms.json` inexistent ref, wrong `hashicorp.asc` path → `security/**`)
+- Fix `build-test.yml` (wrong `hashicorp.asc` path → `security/**`)
+- Fix `dockerhub-description-update.yml` (wrong watched path filter)
+- Refresh `docs/dependencies-upgrades.md` (bullseye → bookworm, accurate package list and paths)
+
+### Phase 1 — Commits, release & OSS governance *(P0)* — folds in #101, #102, #105, part of #98
+The contribution + release machinery. May split into 1a (governance docs) and
+1b (commits/release/bots) if too large.
+- `CONTRIBUTING.md`, `SECURITY.md`, `CODEOWNERS` *(#105)*
+- `.github/PULL_REQUEST_TEMPLATE.md` (ADR checkbox) + `.github/ISSUE_TEMPLATE/` (`bug.yml`, `bump-version.yml`, `feature.yml`) *(#105)*
+- `.commitlintrc.json` + `.github/workflows/commitlint.yml` validating each PR commit **and** the PR title; **strict** failure mode *(#101)*
+- **release-please** config + workflow; migrate `release.yml` to trigger on Release-PR merge; remove the manual release flow *(#101)*
+- Squash-only merge button + `docs/branch-protection.md` (documentary; applied via GitHub UI)
+- Tag strategy applied — P0 subset (`latest`, `vX.Y.Z`, fully-pinned)
+- **Retire `.github/dependabot.yml`; extend `renovate.json`** (grouping, automerge patches, `chore(deps):` prefix, custom manager for `supported_versions.json`) *(#102, relates #20)*
+- Clean `supported_versions.json` — drop Terraform `< 1.0` *(part of #98)*
+- `README.md` governance refresh + badges (CI, latest release, GHCR, cosign) *(#105)*
+- ADR-0001 … ADR-0005, `docs/rollback.md`
+
+### Phase 2 — Claude foundations *(P0)* — Track B
+- `CLAUDE.md` at repo root (sources of truth, ADR rule, no hard-coded values)
+- `.claude/README.md` (framework map) + `docs/claude-framework.md` (architecture, walkthrough, token-cost notes)
+- `docs/claude-framework-conventions.md` (extract of the hard rules above)
+- `.claude/settings.json` — permissions allowlist **+ the role→model mapping** (`orchestrator`/`executor`/`reviewer`) per ADR-0006; no PostToolUse hook yet
+- `.gitignore`: `.claude/settings.local.json` *(done early)*
+- `scripts/claude-session-start.sh` (SessionStart hook)
+- Reconcile with Entire-generated `.claude/settings.json` if Entire is activated (ADR-0007 / `docs/entire-setup.md`)
+
+### Phase 3 — Versions & distribution *(P0)* — folds in #98, #100
+Urgent: current versions are frozen at end-2023 and accrue CVEs.
+- Bump Debian base image (`bookworm-20231120-slim` → recent dated tag) *(#98)*
+- Re-pin APT packages in all stages (`curl`, `gnupg`, `ca-certificates`, `git`, `jq`, `openssh-client`, `unzip`) *(#98)*
+- Add recent Terraform (1.7.x → 1.11.x) and AWS CLI (2.15.x → 2.17.x) to `supported_versions.json`; regenerate `security/` files (`.asc`, `SHA256SUMS`, `.sig`) *(#98)*
+- Bump GitHub Actions (`checkout`, `setup-qemu`, `setup-buildx`, `build-push`, `dockerhub-description`), `container-structure-test`, `hadolint` *(#98)*
+- Rename image `zenika/terraform-aws-cli` → `bgauduch/terraform-aws-cli` everywhere *(#100)*
+- Publish to `ghcr.io/bgauduch/terraform-aws-cli` as second registry *(#100)*
+- Replace `echo | docker login` with `docker/login-action` (DockerHub + GHCR) *(#100, closes #60)*
+- Implement full tag strategy: `latest`, `edge`, `vX.Y.Z`, `vX.Y`, fully-pinned `vX.Y.Z_tf-A.B.C_aws-D.E.F` *(#100)*
+- Enable Docker Scout CVE monitoring *(#100)*
+
+### Phase 4 — CI/CD hardening & code quality *(P1)* — folds in #103, #104
+- Add `pull_request` trigger to `lint-dockerfile` and `build-test` *(#103, closes #46)*
+- Add `concurrency:` to every workflow (cancel stale runs) *(#103)*
+- Harmonise buildx `cache-from` / `cache-to` across workflows *(#103)*
+- Restrict multi-arch build (`amd64,arm64,arm/v7,386`) to publish workflows only *(#103)*
+- `dev.sh`: `getopts` parsing, semver validation, fix `PLATEFORM`→`PLATFORM` typo, `set -euo pipefail` *(#104)*
+- Dockerfile: merge separate `apt-get install` RUN layers in the `terraform` and `aws-cli` stages *(#104)*
+- Extend `container-structure-tests.yml.template`: negative tests (non-root user), binaries-in-`PATH` checks *(#104)*
+
+### Phase 5 — Supply chain security *(P1)* — folds in #99
+- `aquasecurity/trivy-action` in `build-test.yml` — fail on critical, non-patchable *(#99)*
+- SBOM SPDX (`anchore/sbom-action` / `--sbom=true`) attached to releases *(#99)*
+- SLSA provenance attestation (`--attest=type=provenance,mode=max`) *(#99)*
+- cosign keyless signing (OIDC GitHub Actions) of published images *(#99)*
+- Explicit least-privilege `permissions:` on every job *(#99)*
+- `validate-supported-versions.yml` (matrix check `supported_versions.json` ↔ `security/`)
+
+### Phase 6 — Claude skills & subagents *(P1)* — Track B
+Skills (auto-discovered via `SKILL.md` descriptions):
+- `bump-terraform-version`, `bump-awscli-version`, `bump-debian-base`
+- `propose-adr`, `validate-supported-versions`
+- `.githooks/commit-msg` local hook (Docker-based, opt-in; documented in `CONTRIBUTING.md`)
+
+Subagents & slash commands:
+- Downstream `/preflight`: `dockerfile-reviewer`, `security-reviewer` (hadolint + Trivy + GPG chain), `ci-doctor` (workflow paths ↔ files coherence), `commit-message-validator`
+- Upstream `/plan`: single `tech-architect` agent (poses structural questions, flags `adr_required`); `end-user-sre-ci` and `end-user-dev-local` as on-demand consultative agents
+
+### Phase 7 — Durability & bonuses *(P2)*
+- Monthly `health-check-claude-framework.yml`
+- `ossf/scorecard-action` (OpenSSF score) *(#105)*
+- `actions/stale` for PRs/issues
+- "Last reviewed" section in `CLAUDE.md`
+- Multi-arch container-structure-tests (at least `linux/arm64`)
+- Image-size regression guard
+- Integration smoke test (`terraform init`)
+- `wagoodman/dive` image analysis in CI *(#25)*
+- Additional tag aliases if demand emerges (`terraform-A.B.C`, `terraform-A.B`)
+- Re-evaluate the multi-agent panel after 3 months of usage
+
+---
+
+## Open PR & issue disposition
+
+How the existing work is preserved or retired under the reconciled plan.
+
+| Item | Disposition |
+|---|---|
+| PR #116 *(Phase 0)* | Keep — replace its `claude-framework-roadmap.md` with this `docs/roadmap.md`; retain the workflow path fixes |
+| PR #115 *(roadmap doc only)* | **Close** — duplicate, superseded by this document |
+| PR #107 *(semantic-release)* | Rework into Phase 1 with **release-please**; salvage the commitlint parts |
+| PR #109 *(renovate)* | Fold into Phase 1; ensure Dependabot retirement |
+| PR #113 *(docs/governance)* | Fold into Phase 1 |
+| PR #108 *(versions)*, #110 *(distribution)* | Fold into Phase 3 |
+| PR #114 *(CI/CD)*, #112 *(code quality)* | Fold into Phase 4 |
+| PR #111 *(supply chain)* | Fold into Phase 5 |
+| Dependabot PRs #93–#97 | **Close** in favour of Renovate (Phase 1); re-apply needed action bumps in Phase 3 |
+| External PR #90 *(TF/AWS bump)* | Superseded by Phase 3 version work — thank & close |
+| External PR #88 *(python3)* | Tied to the python3 question (#80, #92); decide separately (see below) |
+| Issues #98–#105 *(epics)* | Convert to phase trackers or close once their tasks are absorbed |
+| Issue #106 *(tracking)* | Repoint to this document as the single roadmap |
+| Issues #46, #60, #20, #25 | Addressed within phases (see "closes" annotations) |
+| Issues #13 *(completion)*, #16 *(aws provider)*, #91 *(git-lfs)*, #80/#92 *(python3)*, #81 *(cache-key bug)* | Backlog — not in any phase yet; triage individually |
+
+---
+
+## Explicitly out of scope
+
+- Custom MCP servers
+- `audit-claude-framework` as a Claude skill (replaced by CI)
+- Generic pre-commit framework (Python dependency)
+- Pre-push git hooks (covered by `/preflight` + CI)
+- PostToolUse hook for ADR nudge (unless Claude is observed forgetting in practice)
+- Retroactive backfill of ADRs
+- Image variants (alpine, slim)
+- Bundling python3 in the image (revisit #80/#88/#92 only if demand is strong; document the workaround instead)
+
+## Conventions for evolution
+
+- This roadmap is updated when a decision is added or changed; older entries are
+  not deleted but marked superseded with a pointer to the new ADR.
+- Every structural change requires an ADR. See `.claude/skills/propose-adr`
+  (Phase 6).
+- Every phase delivery is a single PR; the PR description references the phase
+  block above.
+- `CLAUDE.md` and skill files reference sources of truth (JSON files, ADRs)
+  rather than embedding values that drift.


### PR DESCRIPTION
## Summary

Establishes the single source of truth for the repository's modernization and its
**agent development framework**, reconciling the two former plans into one phased
roadmap, and brings the ADR governance forward so the decisions made during
reconciliation are recorded while the rationale is fresh.

Supersedes the standalone roadmap in #115 (closed) and #116 (closed → #119), and
the epic plan in #106 (repointed to `docs/roadmap.md`).

## Changes

- **`docs/roadmap.md`** — single source of truth. Phased backbone (**Phase 0–8**)
  with the former epics #98–#105 folded in as phase content, plus orchestration
  hard rules (role-based, no hard-coded models), a Decisions table, and an open
  PR/issue disposition.
- **`docs/adr/`** — MADR template + **ADR-0001…0009**:
  - 0001 unified roadmap / SSOT · 0002 contribution & release workflow
    (Conventional Commits, squash, **release-please**, **Renovate only**) ·
    0003 image versioning & tag strategy (floating + immutable) · 0004 drop
    Terraform <1.0 · 0005 MADR format · 0006 generic agent orchestration
    (role→model mapping) · 0007 Entire/Checkpoints (Proposed) · 0008 conventional
    branch naming · **0009 agent-agnostic framework with a tool-adapter layer**.
- **Agent-agnostic** — generic core (`AGENTS.md` SSOT, `docs/agent-framework.md`,
  role/tier orchestration); `.claude/` + `CLAUDE.md` are an explicit Claude Code
  **adapter** layer (the tool requires them by name). `CLAUDE.md` imports
  `AGENTS.md` (no duplication).
- **ADR enforcement** — `adr-check.yml` (fails structural-path PRs lacking an
  ADR; bypass with `adr-not-needed`), PR template ADR checkbox, `CODEOWNERS`.
- **entire.io scaffold** — `docs/entire-setup.md` + `.gitignore` for local agent
  settings; activation is a local maintainer step (ADR-0007).

## Decisions validated

Phases backbone · release-please · floating + immutable tags · Renovate only
(Dependabot retired) · generic role/tier agent config · `type/topic` branch
naming · agent-agnostic core + tool adapter · `master`→`main` rename (Phase 8, P2).

## Notes

- Documentation/governance only — no build, Dockerfile or runtime change.
- ⚠️ Before merge: create labels **`needs-adr`** and **`adr-not-needed`** (referenced by `adr-check.yml`).
- Convergence of the in-flight epic PRs is tracked in #106; Phase 0 fixes are in #119.

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (ADR-0001…0009)

https://claude.ai/code/session_01EESGRwTzyd1G16yv7R2Eqd