### PR TITLE
ci: fix workflow path filters (Phase 0)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ on:
     paths:
       - "Dockerfile"
       - "supported_versions.json"
-      - "hashicorp.asc"
+      - "security/**"
       - "tests/*"
       - ".dockerignore"
       - "hadolint.yaml"

--- a/.github/workflows/dockerhub-description-update.yml
+++ b/.github/workflows/dockerhub-description-update.yml
@@ -8,7 +8,7 @@ on:
       - master
     paths:
       - README.md
-      - .github/workflows/dockerhub-description.yml
+      - .github/workflows/dockerhub-description-update.yml
 jobs:
   dockerHubDescription:
     runs-on: ubuntu-22.04

--- a/.github/workflows/push-latest.yml
+++ b/.github/workflows/push-latest.yml
@@ -11,9 +11,8 @@ on:
       - ".github/workflows/push-latest.yml"
       - "Dockerfile"
       - "hadolint.yaml"
-      - "hashicorp.asc"
+      - "security/**"
       - "supported_versions.json"
-      - "supported_platforms.json"
       - "tests/**"
 
 jobs:

--- a/docs/dependencies-upgrades.md
+++ b/docs/dependencies-upgrades.md
@@ -1,15 +1,21 @@
 # ⬆️ Dependencies upgrades checklist
 
 * Supported tools versions:
-  * [Report to the doc](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/docs/binaries-verifications.md) to add required security files when adding a new supported versions
+  * [Report to the doc](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/docs/binaries-verifications.md) to add required security files (stored under `security/`, e.g. `security/hashicorp.asc`) when adding a new supported versions
   * check available **AWS CLI** version on the [project release page](https://github.com/aws/aws-cli/tags)
   * check available **Terraform CLI** version (keep all minor versions from 0.11) on the [project release page](https://github.com/hashicorp/terraform/releases)
 * Dockerfile:
-  * check **base image** version [on DockerHub](https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye)
+  * check **base image** version [on DockerHub](https://hub.docker.com/_/debian?tab=tags&page=1&name=bookworm)
   * check OS package versions on Debian package repository
-    * Available **Git** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bullseye&arch=any&searchon=names&keywords=git)
-    * Available **JQ** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bullseye&arch=any&searchon=names&keywords=jq)
-    * same process for all other packages
+    * Final image stage packages: **ca-certificates**, **git**, **jq**, **openssh-client**
+    * Build stage additional packages: **curl**, **gnupg**, **unzip**
+    * Available **ca-certificates** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=ca-certificates)
+    * Available **Git** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=git)
+    * Available **JQ** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=jq)
+    * Available **openssh-client** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=openssh-client)
+    * Available **curl** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=curl)
+    * Available **gnupg** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=gnupg)
+    * Available **unzip** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=unzip)
 * Dockerfile tests : update version according to changes in Dockerfile in [tests/container-structure-tests.yml.template](tests/container-structure-tests.yml.template)
 * Github actions:
   * check [runner version](https://github.com/actions/virtual-environments#available-environments)


### PR DESCRIPTION
## Summary

Roadmap **Phase 0** (cleanup). Replaces #116 — this carries only the still-valid
parts of that PR (workflow path fixes + dependencies-upgrades refresh), **without**
the now-superseded `docs/claude-framework-roadmap.md` (replaced by `docs/roadmap.md`
in #118).

## Changes

- **`ci`** — fix watched path filters:
  - `push-latest.yml`: drop nonexistent `supported_platforms.json`; `hashicorp.asc` → `security/**`
  - `build-test.yml`: `hashicorp.asc` → `security/**`
  - `dockerhub-description-update.yml`: watch the correct workflow filename
- **`docs`** — refresh `dependencies-upgrades.md` (bookworm, `security/` location, explicit final/build-stage package lists)

## Architecture Decision Record

- [x] Not a structural change — no ADR needed (path-filter corrections + docs)

## Notes

Supersedes #116 (to be closed). Part of the convergence plan in #106.

https://claude.ai/code/session_01EESGRwTzyd1G16yv7R2Eqd

---
_Generated by [Claude Code](https://claude.ai/code/session_01EESGRwTzyd1G16yv7R2Eqd)_