### PR TITLE
docs: add rollback policy guide (Phase 1)

### DIFF
--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -1,0 +1,50 @@
+# Rollback
+
+This image follows the tag strategy in
+[ADR-0003](adr/0003-image-versioning-and-tag-strategy.md). Some tags **float**
+(their meaning moves over time) and one form is **immutable** (it never changes
+meaning). That distinction is what makes rollback safe and predictable.
+
+## Tags and their stability
+
+| Tag form | Example | Stability |
+|---|---|---|
+| `latest` | `latest` | **Floating** — the latest supported tool versions, built from `master` |
+| `vX.Y.Z` | `v8.1.0` | **Floating** project version — resolves to the latest bundled tool versions for that line |
+| `vX.Y.Z_tf-A.B.C_aws-D.E.F` | `v8.1.0_tf-1.6.5_aws-2.14.5` | **Immutable** — one fixed Terraform + AWS CLI combination, never re-pushed |
+
+> Additional floating tags (`edge`, `vX.Y`) and a second registry (GHCR) arrive
+> with roadmap Phase 3 — see [ADR-0003](adr/0003-image-versioning-and-tag-strategy.md).
+
+## Policy
+
+- **Immutable fully-pinned tags are never mutated.** Once
+  `vX.Y.Z_tf-A.B.C_aws-D.E.F` is published, that exact digest is fixed.
+- There is **no "un-release".** A bad release is not deleted or overwritten;
+  rolling back is done by consumers **re-pinning** an older immutable tag.
+
+## How to roll back
+
+1. Pin the **fully-pinned** tag — not a floating one — anywhere you need
+   reproducibility (CI jobs, base images):
+
+   ```dockerfile
+   FROM zenika/terraform-aws-cli:v8.1.0_tf-1.6.5_aws-2.14.5
+   ```
+
+2. To roll back, change the pin to the previous known-good fully-pinned tag:
+
+   ```dockerfile
+   FROM zenika/terraform-aws-cli:v8.0.1_tf-1.6.5_aws-2.14.5
+   ```
+
+3. Browse available tags on the
+   [Docker Hub tags page](https://hub.docker.com/r/zenika/terraform-aws-cli/tags)
+   and the matching changelog on the
+   [GitHub releases page](https://github.com/bgauduch/terraform-aws-cli/releases).
+
+## Why not just delete the bad image?
+
+Deleting or re-pushing a published immutable tag would silently change what
+existing pins resolve to, breaking reproducibility for everyone already pinned to
+it. Re-pinning **forward** to a fixed, known-good tag is the only safe path.


### PR DESCRIPTION
## Summary

Roadmap **Phase 1** — adds `docs/rollback.md`, the rollback policy that **ADR-0003** already links to (`docs/roadmap.md` lists it in both the Decisions table and the Phase 1 deliverables). This resolves that dangling reference.

## Content
- Floating vs immutable tag table (`latest` / `vX.Y.Z` float; `vX.Y.Z_tf-A.B.C_aws-D.E.F` is immutable).
- Policy: immutable fully-pinned tags are never mutated; no "un-release".
- Rollback procedure: re-pin **forward** to an older known-good fully-pinned tag, with examples.

## ADR
No new ADR — documents the policy decided in **ADR-0003**. (Touches only `docs/` → not a structural path, `adr-check` passes; no label needed.)

## Notes
- Keeps the `zenika/` image name pending the Phase 3 org rename (#100).
- `edge` / floating `vX.Y` / GHCR are noted as Phase 3 additions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDmRomapTbonHPFwnU61zR)_