### PR TITLE
docs: link governance docs from README (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,19 @@ TERRAFORM_VERSION=1.5.2
 ```
 
 ## 🙏 Contributions
+
+Before contributing, please read the [contributing guide](CONTRIBUTING.md), the [code of conduct](CODE_OF_CONDUCT.md) and the [security policy](SECURITY.md).
+
 Do not hesitate to contribute by [filling an issue](https://github.com/Zenika/terraform-aws-cli/issues) or [a PR](https://github.com/Zenika/terraform-aws-cli/pulls) !
 
 ## 📚 Documentations
 
-* [Dependencies upgrades checklist](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/docs/dependencies-upgrades.md)
-* [Binaries verifications](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/docs/binaries-verifications.md)
+* [Contributing guide](CONTRIBUTING.md)
+* [Code of conduct](CODE_OF_CONDUCT.md)
+* [Security policy](SECURITY.md)
+* [Rollback policy](docs/rollback.md)
+* [Dependencies upgrades checklist](docs/dependencies-upgrades.md)
+* [Binaries verifications](docs/binaries-verifications.md)
 
 ## 🚩 Similar repositories
 


### PR DESCRIPTION
## Summary

Roadmap **Phase 1** (#105) — surfaces the governance docs added in #120 from the README.

## Changes
- **Contributions** section: links the [contributing guide](CONTRIBUTING.md), [code of conduct](CODE_OF_CONDUCT.md) and [security policy](SECURITY.md).
- **Documentations** section: lists those three + the [rollback policy](docs/rollback.md), and switches the existing two doc links to **relative paths** (org-rename-proof).

## Scope (deliberate)
- **Governance doc links only.** Badges (CI / latest release / GHCR / cosign) and the `zenika→bgauduch` URL rename are **left to Phase 3 (#100) / Phase 5**, to be done in one consistent pass — doing them piecemeal now would mix `bgauduch` and `zenika-open-source` URLs. The stale tag-strategy prose in the README is likewise a Phase 3 (#100) fix.

## Dependency
- The **rollback policy** link points to `docs/rollback.md` from the companion PR (`docs: add rollback policy guide`). **Merge that one first (or together)** to avoid a momentarily dangling link.

## ADR
No new ADR — touches only `README.md` (not a structural path). `adr-check` passes; no label needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDmRomapTbonHPFwnU61zR)_