### PR TITLE
docs: clarify roadmap references, remove volatile phase numbers

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -27,7 +27,7 @@ Chosen option: **<option>**, because <justification>.
 
 - Good: <positive consequence>
 - Bad / cost: <negative consequence or trade-off>
-- Follow-ups: <links to roadmap phase, issues, other ADRs>
+- Follow-ups: <the roadmap, issues, other ADRs — avoid pinning volatile phase or rule numbers that drift>
 
 ## More information
 

--- a/docs/adr/0002-contribution-and-release-workflow.md
+++ b/docs/adr/0002-contribution-and-release-workflow.md
@@ -50,8 +50,9 @@ release state reviewable in a PR.
 - Good: hands-off releases; consistent history; one bot.
 - Cost: contributors must learn Conventional Commits; the in-flight
   Semantic Release work (PR #107) is reworked to release-please.
-- Follow-ups: roadmap Phase 1; Renovate extension tracked with #102/#20;
-  Dependabot PRs #93–#97 close once Renovate covers their scope.
+- Follow-ups: delivered as the roadmap's contribution/release work; Renovate
+  extension tracked with #102/#20; Dependabot PRs #93–#97 close once Renovate
+  covers their scope.
 
 ## More information
 

--- a/docs/adr/0003-image-versioning-and-tag-strategy.md
+++ b/docs/adr/0003-image-versioning-and-tag-strategy.md
@@ -41,10 +41,12 @@ Repo versioning is project semver `vX.Y.Z`; image tags are derived from it.
 - Good: reproducible pins for CI; floating tags for humans.
 - Cost: more tags to publish and document.
 - Policy: immutable full tags are **never** mutated; rollback = consumers
-  re-pin an older tag (see `docs/rollback.md`, roadmap Phase 1).
+  re-pin an older tag.
 - Follows: replaces the old `release-S.T_terraform-…_awscli-…` scheme; supersedes
   the pinned-only proposal in epic #100.
 
 ## More information
 
-Roadmap Phase 1 (P0 subset) and Phase 3 (full strategy + GHCR).
+The strategy is rolled out incrementally on the roadmap: first the P0 subset
+(`latest`, `vX.Y.Z`, fully-pinned), then the full alias set plus GHCR
+publication.

--- a/docs/adr/0004-deprecate-terraform-below-1.0.md
+++ b/docs/adr/0004-deprecate-terraform-below-1.0.md
@@ -26,15 +26,16 @@ build matrix for versions virtually no one should still run.
 
 Chosen option: **drop all Terraform versions `< 1.0`** from
 `supported_versions.json` (and their `security/` artifacts). Recent lines
-(1.7.x → 1.11.x) are added in roadmap Phase 3.
+(1.7.x → 1.11.x) are added later as separate roadmap work.
 
 ### Consequences
 
 - Good: smaller matrix, fewer signature files, clearer support promise.
 - Bad: users pinned to pre-1.0 tags must use an older immutable image tag
   (which remain available — they are immutable, ADR-0003).
-- Follow-ups: roadmap Phase 1 (cleanup) + Phase 3 (add recent versions);
-  `validate-supported-versions` check (Phase 5/6) guards JSON ↔ `security/`.
+- Follow-ups: the cleanup and the later addition of recent versions are tracked
+  on the roadmap; a `validate-supported-versions` check guards
+  `supported_versions.json` ↔ `security/` consistency.
 
 ## More information
 

--- a/docs/adr/0006-agent-orchestration-strategy.md
+++ b/docs/adr/0006-agent-orchestration-strategy.md
@@ -31,10 +31,11 @@ Chosen option: **role/tier abstraction, config-driven**.
 - Define **roles**, not models: `orchestrator`, `executor`, optional `reviewer`.
 - Subagents and docs reference a **role**; never a concrete model name.
 - A **single mapping** lives in the active tool's adapter (`.claude/settings.json`
-  for Claude Code; see ADR-0009), created in roadmap Phase 2:
+  for Claude Code; see ADR-0009), created as part of the agent-foundations
+  roadmap work:
 
   ```jsonc
-  // illustrative shape — authoritative version lands in Phase 2
+  // illustrative shape — the authoritative version lands with the adapter
   {
     "agentRoles": {
       "orchestrator": { "model": "<current-flagship>", "purpose": "planning, review-before-push, ADR drafting, structural decisions" },
@@ -54,8 +55,9 @@ Chosen option: **role/tier abstraction, config-driven**.
 
 - Good: portable, drift-free, one-edit model swaps; consistent with SSOT rule.
 - Cost: one indirection (role → model) to learn.
-- Follow-ups: implemented in roadmap Phase 2 (`.claude/settings.json`,
-  `docs/agent-framework.md`) and Phase 6 (subagents reference roles).
+- Follow-ups: delivered as roadmap work — the role→model mapping
+  (`.claude/settings.json`, `docs/agent-framework.md`), then the subagents that
+  reference roles rather than model names.
 
 ## More information
 

--- a/docs/adr/0007-adopt-entire-checkpoints.md
+++ b/docs/adr/0007-adopt-entire-checkpoints.md
@@ -54,12 +54,12 @@ Session transcripts live on a separate `entire/checkpoints/v1` branch, not on
 
 - Good: durable, searchable agent-session history linked to commits.
 - Risk: early-stage product; account/auth dependency; `.claude/settings.json`
-  overlaps with roadmap Phase 2 — sequence the two together.
+  overlaps with the agent-foundations roadmap work — sequence the two together.
 - Bad: cannot be fully automated from CI (interactive login).
 - Status flips to **Accepted** once activation is committed.
 
 ## More information
 
 - https://entire.io · https://github.com/entireio/cli
-- Sequence with roadmap Phase 2 (Agent foundations) so `.claude/settings.json`
+- Sequence with the agent-foundations roadmap work so `.claude/settings.json`
   is authored once, consistently with ADR-0006.

--- a/docs/adr/0008-conventional-branch-naming.md
+++ b/docs/adr/0008-conventional-branch-naming.md
@@ -36,14 +36,15 @@ branches.
 - Examples: `docs/framework-foundation`, `ci/pr-triggers`,
   `chore/bump-terraform`, `docs/phase-1-oss-governance`.
 
-This replaces hard-rule #7's `claude/phase-N-<topic>` in
+This replaces the earlier `claude/phase-N-<topic>` branch-naming rule in
 [`docs/roadmap.md`](../roadmap.md).
 
 ### Consequences
 
 - Good: tool-agnostic, consistent with commit/PR conventions, still phase-aware.
 - Cost: none material; one rule updated.
-- Follow-ups: roadmap hard-rule #7 updated; Decisions table records this ADR.
+- Follow-ups: the roadmap's branch-naming hard rule is updated; the Decisions
+  table records this ADR.
 
 ## More information
 

--- a/docs/adr/0009-agent-agnostic-framework.md
+++ b/docs/adr/0009-agent-agnostic-framework.md
@@ -54,7 +54,7 @@ Code support" in ADR-0007) remain — they name a real tool, not the framework.
 
 - Good: portable framework; consistent with ADR-0006/0008; one place per tool.
 - Cost: a thin `CLAUDE.md` adapter duplicating a pointer to `AGENTS.md`.
-- Follow-ups: implemented in roadmap Phase 2 (now "Agent foundations"); existing
+- Follow-ups: implemented as the agent-foundations roadmap work; existing
   docs/ADRs reworded in this change.
 
 ## More information

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,8 +42,8 @@ ADRs use the [MADR](https://adr.github.io/madr/) format — see
 ## Creating one
 
 Copy the template, take the next free number, fill it in, and reference it from
-the [roadmap](../roadmap.md) Decisions table. The `propose-adr` skill (roadmap
-Phase 6) will scaffold this automatically.
+the [roadmap](../roadmap.md) Decisions table. A planned `propose-adr` skill will
+scaffold this automatically.
 
 ## Amending vs superseding
 

--- a/docs/dependencies-upgrades.md
+++ b/docs/dependencies-upgrades.md
@@ -16,14 +16,14 @@
     * Available **curl** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=curl)
     * Available **gnupg** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=gnupg)
     * Available **unzip** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=unzip)
-  * OS packages are **pinned to exact versions** in the Dockerfile (see ADR-0010). When a build fails with `apt-get ... exit code 100`, a pin was superseded by Debian — refresh **all** pins to the current candidates, then update the Dockerfile **and** the matching version assertions in [`tests/container-structure-tests.yml.template`](tests/container-structure-tests.yml.template) (e.g. the git/jq/openssh versions):
+  * OS packages are **pinned to exact versions** in the Dockerfile (see ADR-0010). When a build fails with `apt-get ... exit code 100`, a pin was superseded by Debian — refresh **all** pins to the current candidates, then update the Dockerfile **and** the matching version assertions in [`tests/container-structure-tests.yml.template`](../tests/container-structure-tests.yml.template) (e.g. the git/jq/openssh versions):
 
     ```bash
     docker run --rm debian:bookworm-slim bash -c \
       'apt-get update -qq && for p in ca-certificates curl gnupg unzip git jq openssh-client; do \
          printf "%s=%s\n" "$p" "$(apt-cache policy "$p" | awk "/Candidate:/{print \$2}")"; done'
     ```
-* Dockerfile tests : update version according to changes in Dockerfile in [tests/container-structure-tests.yml.template](tests/container-structure-tests.yml.template)
+* Dockerfile tests : update version according to changes in Dockerfile in [tests/container-structure-tests.yml.template](../tests/container-structure-tests.yml.template)
 * Github actions:
   * check [runner version](https://github.com/actions/virtual-environments#available-environments)
   * check **each action release** versions

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -110,7 +110,7 @@ Code) (Phase 2).
 | Dependency bot | **Renovate only** (Dependabot retired) | ADR-0002 |
 | ADR format | MADR (Nygard considered, rejected for simplicity) | ADR-0005 |
 | Terraform deprecation | Drop versions `< 1.0` from `supported_versions.json` | ADR-0004 |
-| APT package pinning | OS utility packages unpinned (stable suite); bundled binaries stay pinned + GPG/checksum verified | ADR-0010 |
+| APT package pinning | OS utility packages **pinned** to exact versions (refreshed when Debian supersedes a pin); bundled binaries stay pinned + GPG/checksum verified | ADR-0010 |
 | Rollback policy | No mutation of immutable full tags; consumers re-pin an older tag | `docs/rollback.md` |
 | ADR enforcement | PR-template checkbox + `adr-check.yml` CI gate + CODEOWNERS (no soft-rule-only) | this doc |
 | Branch naming | `type/topic` (Conventional types), `type/phase-N-topic` for phases; no tool names | ADR-0008 |


### PR DESCRIPTION
## Summary

Removes hardcoded roadmap phase numbers and rule references from ADRs and documentation, replacing them with descriptive language that refers to the roadmap work itself. This decouples ADR text from volatile roadmap structure changes and improves clarity.

**Changes:**
- ADR-0006, ADR-0004, ADR-0003, ADR-0002, ADR-0008, ADR-0007, ADR-0009: Replace "Phase N" references with descriptive roadmap work names (e.g., "agent-foundations roadmap work")
- ADR-0000 (template): Update Follow-ups guidance to discourage pinning volatile phase/rule numbers
- ADR-README: Remove reference to "Phase 6" for `propose-adr` skill; call it "planned"
- `roadmap.md`: Correct APT package pinning policy description (packages **are** pinned, not unpinned)
- `dependencies-upgrades.md`: Fix relative path references to test files

**Rationale:**
ADRs are durable records; roadmap phases shift. By referencing the *work* rather than the *phase number*, ADRs remain accurate even when the roadmap is reorganized. This aligns with the SSOT principle and reduces maintenance burden.

Roadmap phase / closes: Improves ADR durability; no phase closure

## Architecture Decision Record

- [x] This PR is **not** a structural change — no ADR needed

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] No code changes; documentation only

https://claude.ai/code/session_01CBeMUhdsrXREmewd7zZZZG