### PR TITLE
feat(image): migrate base image to Debian 13 (trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Setup build arguments
 ARG AWS_CLI_VERSION
 ARG TERRAFORM_VERSION
-ARG DEBIAN_VERSION=bookworm-20231120-slim
+ARG DEBIAN_VERSION=trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Download Terraform binary
@@ -9,10 +9,10 @@ FROM debian:${DEBIAN_VERSION} as terraform
 ARG TARGETARCH
 ARG TERRAFORM_VERSION
 RUN apt-get update
-RUN apt-get install --no-install-recommends -y ca-certificates=20230311+deb12u1
-RUN apt-get install --no-install-recommends -y curl=7.88.1-10+deb12u14
-RUN apt-get install --no-install-recommends -y gnupg=2.2.40-1.1+deb12u2
-RUN apt-get install --no-install-recommends -y unzip=6.0-28
+RUN apt-get install --no-install-recommends -y ca-certificates=20250419
+RUN apt-get install --no-install-recommends -y curl=8.14.1-2+deb13u4
+RUN apt-get install --no-install-recommends -y gnupg=2.4.7-21+deb13u1
+RUN apt-get install --no-install-recommends -y unzip=6.0-29
 WORKDIR /workspace
 RUN curl --silent --show-error --fail --remote-name https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip
 COPY security/hashicorp.asc ./
@@ -26,12 +26,12 @@ RUN unzip -j terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip
 FROM debian:${DEBIAN_VERSION} as aws-cli
 ARG AWS_CLI_VERSION
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends ca-certificates=20230311+deb12u1
-RUN apt-get install -y --no-install-recommends curl=7.88.1-10+deb12u14
-RUN apt-get install -y --no-install-recommends gnupg=2.2.40-1.1+deb12u2
-RUN apt-get install -y --no-install-recommends unzip=6.0-28
-RUN apt-get install -y --no-install-recommends git=1:2.39.5-0+deb12u3
-RUN apt-get install -y --no-install-recommends jq=1.6-2.1+deb12u1
+RUN apt-get install -y --no-install-recommends ca-certificates=20250419
+RUN apt-get install -y --no-install-recommends curl=8.14.1-2+deb13u4
+RUN apt-get install -y --no-install-recommends gnupg=2.4.7-21+deb13u1
+RUN apt-get install -y --no-install-recommends unzip=6.0-29
+RUN apt-get install -y --no-install-recommends git=1:2.47.3-0+deb13u1
+RUN apt-get install -y --no-install-recommends jq=1.7.1-6+deb13u2
 WORKDIR /workspace
 RUN curl --show-error --fail --output "awscliv2.zip" --remote-name "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip"
 COPY security/awscliv2.asc ./
@@ -46,10 +46,10 @@ FROM debian:${DEBIAN_VERSION} as build
 LABEL maintainer="bgauduch@github"
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-    ca-certificates=20230311+deb12u1 \
-    git=1:2.39.5-0+deb12u3 \
-    jq=1.6-2.1+deb12u1 \
-    openssh-client=1:9.2p1-2+deb12u10 \
+    ca-certificates=20250419 \
+    git=1:2.47.3-0+deb13u1 \
+    jq=1.7.1-6+deb13u2 \
+    openssh-client=1:10.0p1-7+deb13u4 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /workspace

--- a/docs/adr/0010-apt-package-pinning-strategy.md
+++ b/docs/adr/0010-apt-package-pinning-strategy.md
@@ -53,10 +53,14 @@ adopted now, to keep this change minimal.
 
 ## More information
 
+> **Amended 2026-07-20** — the base image moved from `bookworm` to Debian 13
+> (`trixie`) in ADR-0011; the pin-refresh procedure and the read-pins command
+> below now target `trixie`. The pinning *decision* is unchanged.
+
 Pin values are read with:
 
 ```bash
-docker run --rm debian:bookworm-slim bash -c \
+docker run --rm debian:trixie-slim bash -c \
   'apt-get update -qq && for p in ca-certificates curl gnupg unzip git jq openssh-client; do \
      printf "%s=%s\n" "$p" "$(apt-cache policy "$p" | awk "/Candidate:/{print \$2}")"; done'
 ```

--- a/docs/adr/0011-migrate-base-image-to-debian-trixie.md
+++ b/docs/adr/0011-migrate-base-image-to-debian-trixie.md
@@ -1,0 +1,68 @@
+# 0011 — Migrate the base image to Debian 13 (trixie)
+
+- Status: Accepted
+- Date: 2026-07-20
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+The image was built on `debian:bookworm-20231120-slim`, a base frozen at the end
+of 2023. Debian 13 (`trixie`) is now the current stable release, so the old base
+accumulates unpatched CVEs and its pinned `deb12u*` OS-package versions are
+progressively removed from the `bookworm` mirror (the failure mode ADR-0010
+describes). Staying on the frozen base is the single highest-risk item of the
+version-refresh work. The question is which base to move to and how to pin it.
+
+## Decision drivers
+
+- Reduce CVE exposure — ship on a current, maintained Debian release.
+- Reproducibility and supply-chain integrity (consistent with ADR-0010).
+- Predictable, reviewable base-image changes.
+- Low maintenance for a low-traffic project.
+
+## Considered options
+
+- **Move to Debian 13 (`trixie`), pinned by digest** — `trixie-slim` referenced by
+  its immutable `sha256` manifest digest.
+- **Move to `trixie`, pinned by a dated tag** (e.g. `trixie-YYYYMMDD-slim`), as
+  the previous `bookworm-20231120-slim` pin did.
+- **Stay on `bookworm`** and only refresh the OS-package pins. *Rejected — leaves
+  the base a full release behind and does not address the CVE exposure.*
+
+## Decision outcome
+
+Chosen option: **migrate to Debian 13 (`trixie`), pinned by digest**, because the
+digest is immutable and unambiguous (it survives mirror re-tagging), which gives
+stronger reproducibility than a dated tag while requiring no extra tooling. The
+base is set once via the `DEBIAN_VERSION` build arg and consumed by every build
+stage.
+
+The seven pinned OS packages (`ca-certificates`, `curl`, `gnupg`, `unzip`, `git`,
+`jq`, `openssh-client`) are refreshed to their `trixie`/`deb13` candidates per the
+ADR-0010 procedure, and the `container-structure-test` version assertions
+(`git`, `jq`, `ssh`) are updated to match the tools shipped by `trixie`.
+
+This change is intentionally scoped to the **base-image move only**. Refreshing
+the bundled Terraform / AWS CLI version matrix and the image distribution / tag
+work stay separate, so this migration is reviewable on its own.
+
+### Consequences
+
+- Good: current, maintained base → materially reduced CVE surface; digest pin →
+  reproducible, explicit builds.
+- Cost: the OS-package pins and the test assertions must be refreshed together
+  with the base (same ADR-0010 maintenance step); the digest must be bumped when
+  a newer `trixie-slim` is adopted.
+- Follow-ups: the bundled-tool version refresh and the distribution / tag strategy
+  are tracked separately in the roadmap; a `snapshot.debian.org` source (ADR-0010)
+  remains the future path to pins that never break.
+
+## More information
+
+- Supersedes the `bookworm` base recorded implicitly in the Dockerfile; the
+  pinning policy of [`ADR-0010`](0010-apt-package-pinning-strategy.md) is unchanged
+  (amended only to target `trixie`).
+- Pin values and the base digest are read with the procedure in
+  [`docs/dependencies-upgrades.md`](../dependencies-upgrades.md).
+- The bundled-binary verification chain (GPG + checksums) is unchanged
+  ([`docs/binaries-verifications.md`](../binaries-verifications.md)).

--- a/docs/adr/0011-migrate-base-image-to-debian-trixie.md
+++ b/docs/adr/0011-migrate-base-image-to-debian-trixie.md
@@ -53,6 +53,11 @@ work stay separate, so this migration is reviewable on its own.
 - Cost: the OS-package pins and the test assertions must be refreshed together
   with the base (same ADR-0010 maintenance step); the digest must be bumped when
   a newer `trixie-slim` is adopted.
+- Behaviour change: trixie hardens the default `HOME_MODE` to `0700`
+  (`/etc/login.defs`), so the non-root user's home is created `drwx------` instead
+  of bookworm's `drwxr-xr-x`. This is kept as-is (stricter is better; the home is
+  owned by the `nonroot` user) and the container-structure-test assertion is
+  updated to match rather than re-loosening the mode.
 - Follow-ups: the bundled-tool version refresh and the distribution / tag strategy
   are tracked separately in the roadmap; a `snapshot.debian.org` source (ADR-0010)
   remains the future path to pins that never break.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -74,3 +74,4 @@ Rule of thumb: *clarification → amend; reversal → supersede.*
 | [0008](0008-conventional-branch-naming.md) | Conventional branch naming | Accepted |
 | [0009](0009-agent-agnostic-framework.md) | Agent-agnostic framework with a tool-specific adapter layer | Accepted |
 | [0010](0010-apt-package-pinning-strategy.md) | APT package pinning strategy | Accepted |
+| [0011](0011-migrate-base-image-to-debian-trixie.md) | Migrate the base image to Debian 13 (trixie) | Accepted |

--- a/docs/dependencies-upgrades.md
+++ b/docs/dependencies-upgrades.md
@@ -5,21 +5,21 @@
   * check available **AWS CLI** version on the [project release page](https://github.com/aws/aws-cli/tags)
   * check available **Terraform CLI** version (keep one patch per minor, from 1.0 — see ADR-0004) on the [project release page](https://github.com/hashicorp/terraform/releases)
 * Dockerfile:
-  * check **base image** version [on DockerHub](https://hub.docker.com/_/debian?tab=tags&page=1&name=bookworm)
+  * check **base image** version [on DockerHub](https://hub.docker.com/_/debian?tab=tags&page=1&name=trixie)
   * check OS package versions on Debian package repository
     * Final image stage packages: **ca-certificates**, **git**, **jq**, **openssh-client**
     * Build stage additional packages: **curl**, **gnupg**, **unzip**
-    * Available **ca-certificates** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=ca-certificates)
-    * Available **Git** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=git)
-    * Available **JQ** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=jq)
-    * Available **openssh-client** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=openssh-client)
-    * Available **curl** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=curl)
-    * Available **gnupg** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=gnupg)
-    * Available **unzip** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=unzip)
+    * Available **ca-certificates** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=trixie&arch=any&searchon=names&keywords=ca-certificates)
+    * Available **Git** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=trixie&arch=any&searchon=names&keywords=git)
+    * Available **JQ** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=trixie&arch=any&searchon=names&keywords=jq)
+    * Available **openssh-client** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=trixie&arch=any&searchon=names&keywords=openssh-client)
+    * Available **curl** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=trixie&arch=any&searchon=names&keywords=curl)
+    * Available **gnupg** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=trixie&arch=any&searchon=names&keywords=gnupg)
+    * Available **unzip** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=trixie&arch=any&searchon=names&keywords=unzip)
   * OS packages are **pinned to exact versions** in the Dockerfile (see ADR-0010). When a build fails with `apt-get ... exit code 100`, a pin was superseded by Debian — refresh **all** pins to the current candidates, then update the Dockerfile **and** the matching version assertions in [`tests/container-structure-tests.yml.template`](../tests/container-structure-tests.yml.template) (e.g. the git/jq/openssh versions):
 
     ```bash
-    docker run --rm debian:bookworm-slim bash -c \
+    docker run --rm debian:trixie-slim bash -c \
       'apt-get update -qq && for p in ca-certificates curl gnupg unzip git jq openssh-client; do \
          printf "%s=%s\n" "$p" "$(apt-cache policy "$p" | awk "/Candidate:/{print \$2}")"; done'
     ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@
 > - Track A — *"Plan de modernisation"* (issue #106 + epics #98–#105)
 > - Track B — *"Claude Code framework roadmap"* (PRs #115 / #116)
 >
-> Last updated: 2026-06-14 · Status: Phase 0 in progress
+> Last updated: 2026-07-20 · Status: Phases 0–1 complete; Phase 3 (Debian trixie base) in progress
 >
 > Reconciliation decisions validated 2026-06-14:
 > phases backbone (epics folded in as content) · release-please ·
@@ -111,6 +111,7 @@ Code) (Phase 2).
 | ADR format | MADR (Nygard considered, rejected for simplicity) | ADR-0005 |
 | Terraform deprecation | Drop versions `< 1.0` from `supported_versions.json` | ADR-0004 |
 | APT package pinning | OS utility packages **pinned** to exact versions (refreshed when Debian supersedes a pin); bundled binaries stay pinned + GPG/checksum verified | ADR-0010 |
+| Base image | Debian 13 (`trixie`), pinned by immutable `sha256` digest | ADR-0011 |
 | Rollback policy | No mutation of immutable full tags; consumers re-pin an older tag | `docs/rollback.md` |
 | ADR enforcement | PR-template checkbox + `adr-check.yml` CI gate + CODEOWNERS (no soft-rule-only) | this doc |
 | Branch naming | `type/topic` (Conventional types), `type/phase-N-topic` for phases; no tool names | ADR-0008 |
@@ -175,7 +176,7 @@ Agnostic core + a thin Claude Code adapter (ADR-0009).
 
 ### Phase 3 — Versions & distribution *(P0)* — folds in #98, #100
 Urgent: current versions are frozen at end-2023 and accrue CVEs.
-- Bump Debian base image (`bookworm-20231120-slim` → recent dated tag) *(#98)*
+- Bump Debian base image (`bookworm-20231120-slim` → Debian 13 `trixie`, digest-pinned) — **done, ADR-0011** *(#98)*
 - Re-pin APT packages in all stages (`curl`, `gnupg`, `ca-certificates`, `git`, `jq`, `openssh-client`, `unzip`) *(#98)*
 - Add recent Terraform (1.7.x → 1.11.x) and AWS CLI (2.15.x → 2.17.x) to `supported_versions.json`; regenerate `security/` files (`.asc`, `SHA256SUMS`, `.sig`) *(#98)*
 - Bump GitHub Actions (`checkout`, `setup-qemu`, `setup-buildx`, `build-push`, `dockerhub-description`), `container-structure-test`, `hadolint` *(#98)*

--- a/tests/container-structure-tests.yml.template
+++ b/tests/container-structure-tests.yml.template
@@ -11,17 +11,17 @@ commandTests:
   - name: "Check Git version"
     command: "git"
     args: ["--version"]
-    expectedOutput: ["git version 2.39.5"]
+    expectedOutput: ["git version 2.47.3"]
 
   - name: "Check JQ version"
     command: "jq"
     args: ["--version"]
-    expectedOutput: ["jq-1.6"]
+    expectedOutput: ["jq-1.7"]
 
   - name: "Check OpenSSH client version"
     command: "ssh"
     args: ["-V"]
-    expectedError: ["OpenSSH_9.2p1"]
+    expectedError: ["OpenSSH_10.0p2"]
 
   - name: "Check Terraform CLI version"
     command: "terraform"

--- a/tests/container-structure-tests.yml.template
+++ b/tests/container-structure-tests.yml.template
@@ -37,10 +37,11 @@ fileExistenceTests:
   - name: 'Check non-root user home'
     path: '/home/nonroot'
     shouldExist: true
-    permissions: 'drwxr-xr-x'
+    # Debian 13 (trixie) defaults HOME_MODE to 0700 (drwx------), stricter than
+    # bookworm's 0755 — see ADR-0011. The home is owned by the nonroot user.
+    permissions: 'drwx------'
     uid: 1001
     gid: 1001
-    isExecutableBy: 'group'
   - name: 'Check non-root user rights on /workspace folder'
     path: '/workspace'
     shouldExist: true


### PR DESCRIPTION
## Summary

Migrates the image base from `bookworm-20231120-slim` (frozen at end-2023) to
**Debian 13 (`trixie`)**, pinned by its immutable `sha256` digest, and refreshes
every OS package pin to its `deb13` candidate. This is the highest-value slice of
the version work: the old base accrues CVEs and its `deb12u*` pins are progressively
removed from the mirror.

**Changes**
- `Dockerfile`: base → `trixie-slim@sha256:020c…a7bd`; the 7 pinned packages
  (`ca-certificates`, `curl`, `gnupg`, `unzip`, `git`, `jq`, `openssh-client`)
  refreshed to their `deb13` versions across all three stages.
- `tests/container-structure-tests.yml.template`: `git`/`jq`/`ssh` version
  assertions updated to what `trixie` ships (`2.47.3`, `jq-1.7`, `OpenSSH_10.0p2`).
- `docs/dependencies-upgrades.md`: package-search suite, DockerHub tag and the
  read-pins one-liner flipped `bookworm` → `trixie`.
- `docs/adr/0011-migrate-base-image-to-debian-trixie.md`: **new ADR** recording the
  decision (digest-pinned trixie); `docs/adr/0010` amended (example command) + index
  updated; roadmap Decisions row + header refreshed.

**Verification (run against `debian:trixie-slim`)**
- Base `tag@digest` reference resolves.
- All 7 **exact** pins install cleanly on trixie (not just the candidates).
- Assertion values taken from real tool output (`ssh -V` → `10.0p2`).
- `hadolint 2.12.0` clean.

**Out of scope (rest of Phase 3, tracked separately):** the Terraform/AWS CLI
version-matrix additions + `security/` regen (#98), GitHub Actions bumps, and the
distribution/tags + `zenika→bgauduch` rename (#100).

Roadmap phase / closes: Phase 3 (Debian base migration) — relates #98

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (link: `docs/adr/0011-migrate-base-image-to-debian-trixie.md`)
- [ ] This PR is **not** a structural change — no ADR needed

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Touches only files within the declared phase scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeiH1ZwZE7UUYEE1tjKRrm)_