### PR TITLE
chore(agent): add SessionStart bootstrap and Claude Code adapter config

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,25 @@
+# `.claude/` — Claude Code adapter layer
+
+This directory is the **tool-specific adapter** for Claude Code (ADR-0009). The
+tool-agnostic instructions and rules live in [`AGENTS.md`](../AGENTS.md) and the
+docs it points to; this directory only holds what Claude Code reads by name.
+
+| Path | Purpose |
+|---|---|
+| `settings.json` | Committed Claude Code settings: the **SessionStart hook** wiring (→ `scripts/agent-session-start.sh`), the **role→model mapping** (ADR-0006, tier aliases so model swaps are one edit and drift-free), and a small verify-workflow permission allow-list. |
+| `settings.local.json` | Personal, machine-specific overrides. **Git-ignored** — never committed. |
+
+Related, outside this directory:
+
+- [`scripts/agent-session-start.sh`](../scripts/agent-session-start.sh) — the
+  agnostic bootstrap the hook runs (Docker daemon behind the egress proxy +
+  resume pointer). Kept out of `.claude/` so another agent's adapter can reuse it.
+- [`docs/agent-framework.md`](../docs/agent-framework.md) — how the framework and
+  the local verify harness fit together.
+- [`AGENTS.md`](../AGENTS.md) · [`docs/agent-conventions.md`](../docs/agent-conventions.md)
+  · [`docs/roadmap.md`](../docs/roadmap.md) · [`docs/adr/`](../docs/adr/) — the
+  agnostic sources of truth.
+
+> Roles are referenced by name everywhere; the concrete model per role lives
+> **only** in `settings.json` (ADR-0006). Swapping a model is a one-line change
+> here, not a doc-wide edit.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,25 +1,15 @@
 # `.claude/` — Claude Code adapter layer
 
-This directory is the **tool-specific adapter** for Claude Code (ADR-0009). The
-tool-agnostic instructions and rules live in [`AGENTS.md`](../AGENTS.md) and the
-docs it points to; this directory only holds what Claude Code reads by name.
+Tool-specific adapter for Claude Code (ADR-0009). Instructions and rules live in
+[`AGENTS.md`](../AGENTS.md) and the docs it points to; this directory holds only
+what Claude Code reads by name.
 
 | Path | Purpose |
 |---|---|
-| `settings.json` | Committed Claude Code settings: the **SessionStart hook** wiring (→ `scripts/agent-session-start.sh`), the **role→model mapping** (ADR-0006, tier aliases so model swaps are one edit and drift-free), and a small verify-workflow permission allow-list. |
-| `settings.local.json` | Personal, machine-specific overrides. **Git-ignored** — never committed. |
+| `settings.json` | SessionStart hook wiring (→ `scripts/agent-session-start.sh`), the role→model mapping (ADR-0006), and a verify-workflow permission allow-list. |
+| `settings.local.json` | Personal overrides. **Git-ignored** — never committed. |
 
-Related, outside this directory:
-
-- [`scripts/agent-session-start.sh`](../scripts/agent-session-start.sh) — the
-  agnostic bootstrap the hook runs (Docker daemon behind the egress proxy +
-  resume pointer). Kept out of `.claude/` so another agent's adapter can reuse it.
-- [`docs/agent-framework.md`](../docs/agent-framework.md) — how the framework and
-  the local verify harness fit together.
-- [`AGENTS.md`](../AGENTS.md) · [`docs/agent-conventions.md`](../docs/agent-conventions.md)
-  · [`docs/roadmap.md`](../docs/roadmap.md) · [`docs/adr/`](../docs/adr/) — the
-  agnostic sources of truth.
-
-> Roles are referenced by name everywhere; the concrete model per role lives
-> **only** in `settings.json` (ADR-0006). Swapping a model is a one-line change
-> here, not a doc-wide edit.
+The bootstrap the hook runs lives in
+[`scripts/agent-session-start.sh`](../scripts/agent-session-start.sh) (kept out of
+`.claude/` so other adapters can reuse it); the framework overview is in
+[`docs/agent-framework.md`](../docs/agent-framework.md).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/agent-session-start.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "agentRoles": {
+    "orchestrator": {
+      "model": "opus",
+      "purpose": "planning, diff review before push, ADR drafting, structural decisions"
+    },
+    "executor": {
+      "model": "sonnet",
+      "purpose": "scoped implementation, refactors, docs"
+    },
+    "reviewer": {
+      "model": "sonnet",
+      "purpose": "diff review, security and lint passes"
+    }
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(jq:*)",
+      "Bash(docker info)",
+      "Bash(docker version)",
+      "Bash(docker pull:*)"
+    ]
+  }
+}

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -1,0 +1,80 @@
+# Agent framework
+
+How the agent development framework of this repository is put together, and how
+to **verify a change locally before pushing it**. This is the architecture note;
+the binding rules are in [`docs/agent-conventions.md`](agent-conventions.md) and
+the entry point is [`AGENTS.md`](../AGENTS.md).
+
+## Architecture: agnostic core + tool adapter (ADR-0009)
+
+```
+AGENTS.md ─────────────► tool-agnostic entry point (any agent reads this)
+  ├─ docs/agent-conventions.md   the binding hard rules (SSOT)
+  ├─ docs/roadmap.md             the plan (phases, decisions)
+  └─ docs/adr/                   the decisions + rationale
+
+CLAUDE.md ─────────────► thin Claude Code adapter → points at AGENTS.md
+  └─ .claude/
+       ├─ settings.json          SessionStart hook wiring + role→model map + perms
+       └─ README.md              adapter map
+
+scripts/agent-session-start.sh ► agnostic bootstrap (reused by the adapter)
+```
+
+Another agent (e.g. a different CLI) adds its own thin adapter and reuses the
+agnostic core unchanged.
+
+### Roles, not models (ADR-0006)
+
+Work is organised by **role** — `orchestrator` (planning, diff review before
+push, ADR drafting), `executor` (scoped implementation), `reviewer` (diff /
+security / lint). Docs cite the role; the concrete model per role lives **only**
+in `.claude/settings.json` (tier aliases, so a swap is one edit and never drifts
+into prose).
+
+### PR autonomy (ADR-0012)
+
+The agent opens PRs and drives their CI to green; the human owns the merge. The
+local verify harness below is what makes that safe — a change is checked before
+it is pushed, so "green locally" predicts "green in CI".
+
+## The local verify harness
+
+The image is built from a Debian base with **exact-pinned** OS packages
+(ADR-0010) on a **digest-pinned** base (ADR-0011). The recurring risk is a base
+bump or a superseded pin. The [`scripts/agent-session-start.sh`](../scripts/agent-session-start.sh)
+SessionStart hook brings up a Docker daemon **behind the egress proxy** (the
+proxy re-terminates TLS; the daemon uses the proxy env for pulls and the CA is
+trusted system-wide) so the checks below work with no manual setup.
+
+### What runs locally (fast feedback)
+
+- **Lint** — `hadolint` on the `Dockerfile` (same version as CI), via
+  `dev.sh` or directly.
+- **Base pull + pin gather** — pull the target base and read the candidate OS
+  package versions (the procedure in
+  [`docs/dependencies-upgrades.md`](dependencies-upgrades.md)).
+- **Pin install check** — confirm the *exact* pins actually install on the
+  target base (catches a superseded pin before CI does).
+- **Assertion values** — read the real tool outputs (`git --version`,
+  `jq --version`, `ssh -V`, home-dir mode) that the
+  `container-structure-test` assertions must match.
+
+> Package/apt traffic inside a container must go through the proxy over **HTTPS**
+> (`--network=host`, `https_proxy`, and the sources switched to `https://` with
+> the CA bundle) — the proxy only tunnels HTTPS/CONNECT, plain HTTP returns 405.
+> This is the recipe the session-start bootstrap and the steps above rely on.
+
+### What stays in CI (authoritative gate)
+
+The **full multi-arch image build** (`linux/amd64,arm64,arm/v7,386`) and the
+end-to-end `container-structure-test` run on GitHub Actions — that is the
+authoritative gate. The local harness deliberately covers lint, base pull, pin
+install and assertion values: the fast checks that catch most breakage. It does
+**not** reproduce the full multi-arch build locally, so CI remains the final say.
+
+## Resuming a session
+
+A fresh session should read, in order: tracking issue **#106** (live status),
+[`AGENTS.md`](../AGENTS.md) (rules), [`docs/roadmap.md`](roadmap.md) (plan) and
+[`docs/adr/`](adr/) (decisions). The SessionStart hook prints this pointer.

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -1,14 +1,14 @@
 # Agent framework
 
 How the framework fits together and how to **verify an image change locally
-before pushing**. Rules: [`docs/agent-conventions.md`](agent-conventions.md);
+before pushing**. Rules: [`docs/conventions.md`](conventions.md);
 entry point: [`AGENTS.md`](../AGENTS.md).
 
 ## Architecture: agnostic core + tool adapter (ADR-0009)
 
 ```
 AGENTS.md ─────────────► tool-agnostic entry point (any agent reads this)
-  ├─ docs/agent-conventions.md   the binding hard rules
+  ├─ docs/conventions.md   the binding hard rules
   ├─ docs/roadmap.md             the plan
   └─ docs/adr/                   the decisions + rationale
 

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -1,14 +1,14 @@
 # Agent framework
 
 How the framework fits together and how to **verify an image change locally
-before pushing**. Rules: [`docs/conventions.md`](conventions.md);
-entry point: [`AGENTS.md`](../AGENTS.md).
+before pushing**. Working conventions: [`docs/conventions.md`](conventions.md);
+agent entry point and session rules: [`AGENTS.md`](../AGENTS.md).
 
 ## Architecture: agnostic core + tool adapter (ADR-0009)
 
 ```
-AGENTS.md ─────────────► tool-agnostic entry point (any agent reads this)
-  ├─ docs/conventions.md   the binding hard rules
+AGENTS.md ─────────────► agent entry point + session rules (any agent reads this)
+  ├─ docs/conventions.md         the shared working conventions
   ├─ docs/roadmap.md             the plan
   └─ docs/adr/                   the decisions + rationale
 

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -1,80 +1,53 @@
 # Agent framework
 
-How the agent development framework of this repository is put together, and how
-to **verify a change locally before pushing it**. This is the architecture note;
-the binding rules are in [`docs/agent-conventions.md`](agent-conventions.md) and
-the entry point is [`AGENTS.md`](../AGENTS.md).
+How the framework fits together and how to **verify an image change locally
+before pushing**. Rules: [`docs/agent-conventions.md`](agent-conventions.md);
+entry point: [`AGENTS.md`](../AGENTS.md).
 
 ## Architecture: agnostic core + tool adapter (ADR-0009)
 
 ```
 AGENTS.md ─────────────► tool-agnostic entry point (any agent reads this)
-  ├─ docs/agent-conventions.md   the binding hard rules (SSOT)
-  ├─ docs/roadmap.md             the plan (phases, decisions)
+  ├─ docs/agent-conventions.md   the binding hard rules
+  ├─ docs/roadmap.md             the plan
   └─ docs/adr/                   the decisions + rationale
 
-CLAUDE.md ─────────────► thin Claude Code adapter → points at AGENTS.md
-  └─ .claude/
-       ├─ settings.json          SessionStart hook wiring + role→model map + perms
-       └─ README.md              adapter map
+CLAUDE.md ─────────────► thin Claude Code adapter → AGENTS.md
+  └─ .claude/{settings.json, README.md}   hook wiring + role→model map + perms
 
 scripts/agent-session-start.sh ► agnostic bootstrap (reused by the adapter)
 ```
 
-Another agent (e.g. a different CLI) adds its own thin adapter and reuses the
-agnostic core unchanged.
-
-### Roles, not models (ADR-0006)
-
-Work is organised by **role** — `orchestrator` (planning, diff review before
-push, ADR drafting), `executor` (scoped implementation), `reviewer` (diff /
-security / lint). Docs cite the role; the concrete model per role lives **only**
-in `.claude/settings.json` (tier aliases, so a swap is one edit and never drifts
-into prose).
-
-### PR autonomy (ADR-0012)
-
-The agent opens PRs and drives their CI to green; the human owns the merge. The
-local verify harness below is what makes that safe — a change is checked before
-it is pushed, so "green locally" predicts "green in CI".
+Work is organised by **role** (`orchestrator`/`executor`/`reviewer`, ADR-0006);
+the model per role lives only in `.claude/settings.json`. Another agent adds its
+own adapter and reuses the core unchanged.
 
 ## The local verify harness
 
-The image is built from a Debian base with **exact-pinned** OS packages
-(ADR-0010) on a **digest-pinned** base (ADR-0011). The recurring risk is a base
-bump or a superseded pin. The [`scripts/agent-session-start.sh`](../scripts/agent-session-start.sh)
-SessionStart hook brings up a Docker daemon **behind the egress proxy** (the
-proxy re-terminates TLS; the daemon uses the proxy env for pulls and the CA is
-trusted system-wide) so the checks below work with no manual setup.
+Why it matters: the agent opens PRs and drives their CI to green (ADR-0012), so a
+change should be checked *before* it is pushed — "green locally" should predict
+"green in CI".
 
-### What runs locally (fast feedback)
+The image uses **exact-pinned** OS packages (ADR-0010) on a **digest-pinned** base
+(ADR-0011); the recurring risk is a base bump or a superseded pin. The
+[`scripts/agent-session-start.sh`](../scripts/agent-session-start.sh) SessionStart
+hook brings up a Docker daemon **behind the egress proxy** (proxy env for pulls,
+CA trusted system-wide) so the checks below need no manual setup.
 
-- **Lint** — `hadolint` on the `Dockerfile` (same version as CI), via
-  `dev.sh` or directly.
-- **Base pull + pin gather** — pull the target base and read the candidate OS
-  package versions (the procedure in
-  [`docs/dependencies-upgrades.md`](dependencies-upgrades.md)).
-- **Pin install check** — confirm the *exact* pins actually install on the
-  target base (catches a superseded pin before CI does).
-- **Assertion values** — read the real tool outputs (`git --version`,
-  `jq --version`, `ssh -V`, home-dir mode) that the
-  `container-structure-test` assertions must match.
+### Runs locally (fast feedback)
 
-> Package/apt traffic inside a container must go through the proxy over **HTTPS**
-> (`--network=host`, `https_proxy`, and the sources switched to `https://` with
-> the CA bundle) — the proxy only tunnels HTTPS/CONNECT, plain HTTP returns 405.
-> This is the recipe the session-start bootstrap and the steps above rely on.
+- **Lint** — `hadolint` on the `Dockerfile` (CI's version), via `dev.sh` or directly.
+- **Base pull + pin gather** — pull the target base, read candidate OS package versions ([`docs/dependencies-upgrades.md`](dependencies-upgrades.md)).
+- **Pin install check** — confirm the *exact* pins install on the target base (catches a superseded pin before CI).
+- **Assertion values** — read the real tool outputs (`git`/`jq`/`ssh` versions, home-dir mode) the `container-structure-test` assertions must match.
 
-### What stays in CI (authoritative gate)
+> apt traffic inside a container must go through the proxy over **HTTPS**
+> (`--network=host`, `https_proxy`, sources switched to `https://` + the CA
+> bundle) — the proxy only tunnels HTTPS/CONNECT; plain HTTP returns 405.
 
-The **full multi-arch image build** (`linux/amd64,arm64,arm/v7,386`) and the
-end-to-end `container-structure-test` run on GitHub Actions — that is the
-authoritative gate. The local harness deliberately covers lint, base pull, pin
-install and assertion values: the fast checks that catch most breakage. It does
-**not** reproduce the full multi-arch build locally, so CI remains the final say.
+### Stays in CI (authoritative gate)
 
-## Resuming a session
-
-A fresh session should read, in order: tracking issue **#106** (live status),
-[`AGENTS.md`](../AGENTS.md) (rules), [`docs/roadmap.md`](roadmap.md) (plan) and
-[`docs/adr/`](adr/) (decisions). The SessionStart hook prints this pointer.
+The full multi-arch build (`amd64,arm64,arm/v7,386`) + end-to-end
+`container-structure-test` run on GitHub Actions — the final say. The local harness
+covers lint, base pull, pin install and assertion values (the fast checks that
+catch most breakage); it does not reproduce the multi-arch build.

--- a/scripts/agent-session-start.sh
+++ b/scripts/agent-session-start.sh
@@ -50,7 +50,7 @@ fi
 cat >&2 <<'PTR'
 [agent-session-start] Resume here:
   * tracking issue #106  — live status, open PRs/issues, next actions (status SSOT)
-  * AGENTS.md            — rules entry point (-> docs/agent-conventions.md)
+  * AGENTS.md            — rules entry point (-> docs/conventions.md)
   * docs/roadmap.md      — the plan (phases, decisions)
   * docs/adr/            — the decisions and their rationale
   Local image verify recipe (Debian/version bumps): docs/agent-framework.md

--- a/scripts/agent-session-start.sh
+++ b/scripts/agent-session-start.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Agent SessionStart bootstrap (agnostic core; wired by the Claude Code adapter
+# in .claude/settings.json). Makes a remote agent session build- and
+# verify-ready so a change to the image can be checked locally before it is
+# pushed — hadolint, base-image pulls and OS-package pin gathering all need a
+# Docker daemon that can reach the network through the egress proxy.
+#
+# What it does (idempotent, non-interactive):
+#   1. Starts the Docker daemon behind the egress proxy, with the proxy CA
+#      trusted, if a daemon is not already running.
+#   2. Prints a "resume here" pointer to the sources of truth.
+#
+# The full multi-arch image build stays in CI; locally this unblocks lint,
+# base-image pulls, pin installs and the version assertions — the checks that
+# catch most breakage before a push. See docs/agent-framework.md.
+#
+set -euo pipefail
+
+log() { printf '[agent-session-start] %s\n' "$*" >&2; }
+
+# Only meaningful in the remote (Claude Code on the web) sandbox; a local
+# workstation already has its own Docker setup.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# 1) Docker daemon, behind the egress proxy, CA trusted.
+#    The proxy re-terminates TLS, so the daemon must use the proxy env for pulls;
+#    the CA bundle is already in the system trust store in this environment.
+if command -v docker >/dev/null 2>&1; then
+  if docker info >/dev/null 2>&1; then
+    log "docker daemon already running"
+  elif command -v dockerd >/dev/null 2>&1; then
+    log "starting dockerd (proxy: ${HTTPS_PROXY:-none})"
+    sudo env \
+      HTTP_PROXY="${HTTP_PROXY:-}"  HTTPS_PROXY="${HTTPS_PROXY:-}"  NO_PROXY="${NO_PROXY:-}" \
+      http_proxy="${HTTP_PROXY:-}"  https_proxy="${HTTPS_PROXY:-}"  no_proxy="${NO_PROXY:-}" \
+      dockerd >/tmp/agent-dockerd.log 2>&1 &
+    for _ in $(seq 1 20); do docker info >/dev/null 2>&1 && break; sleep 1; done
+  fi
+  docker info >/dev/null 2>&1 \
+    && log "docker ready — local lint/pull/pin-verify available" \
+    || log "docker unavailable — see /tmp/agent-dockerd.log (local image checks limited)"
+else
+  log "docker CLI not found — skipping daemon bootstrap"
+fi
+
+# 2) Resume pointer — where the plan and live status live.
+cat >&2 <<'PTR'
+[agent-session-start] Resume here:
+  * tracking issue #106  — live status, open PRs/issues, next actions (status SSOT)
+  * AGENTS.md            — rules entry point (-> docs/agent-conventions.md)
+  * docs/roadmap.md      — the plan (phases, decisions)
+  * docs/adr/            — the decisions and their rationale
+  Local image verify recipe (Debian/version bumps): docs/agent-framework.md
+PTR
+
+exit 0


### PR DESCRIPTION
## Summary

Second slice of **Phase 2 — agent foundations**: the **local verify harness** +
the Claude Code adapter config (ADR-0009). This is what makes the agent-driven
PR flow (ADR-0012) safe — a session can check an image change *before* pushing,
so "green locally" predicts "green in CI".

**Changes**
- **`scripts/agent-session-start.sh`** — agnostic SessionStart bootstrap: brings
  up the Docker daemon **behind the egress proxy** (proxy env + trusted CA) so
  `hadolint`, base-image pulls and OS-package pin checks work with no manual
  setup; prints a resume pointer to #106 + the SSOT docs. Idempotent, remote-only
  (`CLAUDE_CODE_REMOTE`), synchronous.
- **`.claude/settings.json`** — wires the hook as a `SessionStart` command, the
  **role→model mapping** (ADR-0006 — tier aliases so a swap is one drift-free
  edit), and a small verify-workflow permission allow-list.
- **`.claude/README.md`** — adapter map.
- **`docs/agent-framework.md`** — architecture + the local verify harness
  (validated recipe for Debian/version bumps) with its honest boundary: the full
  multi-arch build stays in CI.

Follow-up commits applied the strict-SSOT pass and aligned all pointers with the
doc tree from #134: `docs/conventions.md` (shared working conventions) +
`AGENTS.md` (agent entry point carrying the session rules).

**Depends on:** #134 for `AGENTS.md` / `docs/conventions.md`, which this
references. Both target `master`; merge order does not matter (links resolve
once both land).

Roadmap phase / closes: Phase 2 (agent foundations) — relates #106

## Architecture Decision Record

This PR touches a structural path (`.claude/`) but **implements existing ADRs**
(ADR-0006 role mapping, ADR-0009 adapter layer, ADR-0012 PR autonomy) — it
records no new decision. `adr-not-needed` label applied.

- [ ] This PR adds/updates an ADR under `docs/adr/`
- [x] Implements existing ADRs — `adr-not-needed` (no new decision)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)