### PR TITLE
docs(roadmap): add historical image release migration to the distribution work

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -182,6 +182,10 @@ Urgent: current versions are frozen at end-2023 and accrue CVEs.
 - Bump GitHub Actions (`checkout`, `setup-qemu`, `setup-buildx`, `build-push`, `dockerhub-description`), `container-structure-test`, `hadolint` *(#98)*
 - Rename image `zenika/terraform-aws-cli` → `bgauduch/terraform-aws-cli` everywhere *(#100)*
 - Publish to `ghcr.io/bgauduch/terraform-aws-cli` as second registry *(#100)*
+- Migrate the historical releases from the legacy `zenika/terraform-aws-cli`
+  Docker Hub repository to `bgauduch/terraform-aws-cli` — copy **all tags with
+  multi-arch manifests preserved** (`skopeo copy --all`), tags kept as-is
+  *(#137 — one-shot, after the new repo + secrets exist)*
 - Replace `echo | docker login` with `docker/login-action` (DockerHub + GHCR) *(#100, closes #60)*
 - Implement full tag strategy: `latest`, `edge`, `vX.Y.Z`, `vX.Y`, fully-pinned `vX.Y.Z_tf-A.B.C_aws-D.E.F` *(#100)*
 - Enable Docker Scout CVE monitoring *(#100)*


### PR DESCRIPTION
## Summary

Adds one item to the Phase 3 distribution block: the **one-shot migration of
every legacy `zenika/terraform-aws-cli` Docker Hub tag** to
`bgauduch/terraform-aws-cli` (`skopeo copy --all`, multi-arch manifests
preserved, tags kept as-is), so the release history survives the org move.

Plan, prerequisites and acceptance criteria: **#137**. GHCR publication and the
new Docker Hub repository were already tracked (#100); this only adds the
history-migration item — no duplication.

Roadmap phase / closes: roadmap update only — relates #137, #100, #106

## Architecture Decision Record

- [ ] This PR adds/updates an ADR under `docs/adr/` (link: ____)
- [x] This PR is **not** a structural change — no ADR needed

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Touches only files within the declared phase scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeiH1ZwZE7UUYEE1tjKRrm)_