### PR TITLE
ci: run lint and build-test on pull requests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,15 +1,10 @@
 name: build-test
 
-# trigger on any push
-# but not on master or tags
-# and only for dockerfile-related modifications
+# Runs on pull requests (tests the merge result; covers fork contributions).
+# Fork PRs get no secrets and a read-only token by design — this workflow must
+# stay secret-free, and pull_request_target is banned. See ADR-0013.
 on:
-  push:
-    tags-ignore:
-      - "**"
-    branches:
-      - "**"
-      - "!master"
+  pull_request:
     paths:
       - "Dockerfile"
       - "supported_versions.json"
@@ -18,6 +13,13 @@ on:
       - ".dockerignore"
       - "hadolint.yaml"
       - ".github/workflows/build-test.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   IMAGE_NAME: "terraform-aws-cli"

--- a/.github/workflows/lint-dockerfile.yml
+++ b/.github/workflows/lint-dockerfile.yml
@@ -1,18 +1,19 @@
 name: lint-dockerfile
 
-# trigger on any push
-# but not on master or tags
-# and only for dockerfile related modifications
+# Runs on pull requests (tests the merge result; covers fork contributions).
+# Secret-free by design; pull_request_target is banned. See ADR-0013.
 on:
-  push:
-    tags-ignore:
-      - "**"
-    branches:
-      - "**"
-      - "!master"
+  pull_request:
     paths:
       - "Dockerfile"
       - ".github/workflows/lint-dockerfile.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/docs/adr/0013-pr-triggered-ci-security-boundary.md
+++ b/docs/adr/0013-pr-triggered-ci-security-boundary.md
@@ -1,0 +1,66 @@
+# 0013 — PR-triggered CI and its security boundary
+
+- Status: Accepted
+- Date: 2026-07-22
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+`lint-dockerfile` and `build-test` only triggered on branch pushes, so pull
+requests from forks — the normal community contribution path — never ran a
+single CI build before review (#46). Adding a PR trigger raises a security
+question: GitHub Actions on PR-controlled code has known attack classes
+(secret exfiltration, privilege escalation via `pull_request_target`), so the
+boundary must be explicit.
+
+## Decision drivers
+
+- Every contribution, including fork PRs, must be build-verified before merge.
+- No path from PR-controlled code to repository secrets or write access.
+- Full test coverage on PRs (all supported versions, all platforms) —
+  maintainer decision; compute abuse is mitigated by approval gates, not by
+  reducing coverage.
+
+## Considered options
+
+- **`pull_request` on secret-free workflows.** Fork runs get **no secrets and a
+  read-only `GITHUB_TOKEN` by design**; the workflow definition itself may be
+  attacker-modified, but there is nothing to exfiltrate. Chosen.
+- **`pull_request_target`** — runs PR code with base-repo secrets and a write
+  token; the "pwn request" class. *Rejected — banned in this repository.*
+- **Keep push-only triggers** — leaves fork PRs unverified. *Rejected.*
+
+## Decision outcome
+
+Chosen option: **`pull_request` triggers on the secret-free CI workflows**
+(`lint-dockerfile`, `build-test`), replacing their branch-push triggers (a PR
+run tests the merge result, and one run replaces two).
+
+The security boundary, binding for all future workflow changes:
+
+1. **A workflow triggered by `pull_request` MUST NOT use secrets.** The
+   publication fix and any future secret-consuming step live only in
+   push-to-`master` / release workflows.
+2. **`pull_request_target` MUST NOT be used** in this repository.
+3. **Publishing workflows keep their push-to-`master` trigger** and are never
+   given PR triggers.
+4. Workflows declare least-privilege `permissions:` explicitly
+   (`contents: read` for CI), and `concurrency` cancels superseded runs.
+5. Fork-run approval policy (who may trigger CI) is a GitHub repository
+   setting, maintainer-managed in the UI — referenced here, not mirrored.
+
+### Consequences
+
+- Good: every PR — including forks — is lint- and build-verified across the
+  full version matrix and all platforms; no secret exposure by construction.
+- Cost: a branch pushed without a PR no longer runs build CI (open the PR to
+  get CI — the normal flow); full-coverage fork runs cost compute, gated by
+  the approval setting.
+- Follow-ups: buildx cache hardening and multi-arch scoping belong to the
+  CI/CD roadmap work (#103).
+
+## More information
+
+- GitHub: [Securely using pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target),
+  [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use).
+- Closes #46; part of epic #103.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -85,3 +85,4 @@ Rule of thumb: *clarification → amend; reversal → supersede.*
 | [0010](0010-apt-package-pinning-strategy.md) | APT package pinning strategy | Accepted |
 | [0011](0011-migrate-base-image-to-debian-trixie.md) | Migrate the base image to Debian 13 (trixie) | Accepted |
 | [0012](0012-agent-opens-and-drives-pull-requests.md) | The agent opens and drives pull requests; the human owns the merge | Accepted |
+| [0013](0013-pr-triggered-ci-security-boundary.md) | PR-triggered CI and its security boundary | Accepted |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -70,6 +70,7 @@ to green; the human owns the merge).
 | Agent-agnostic framework | Generic core (agnostic docs + naming, role/tier orchestration); `.claude/` + `CLAUDE.md` are the Claude Code **adapter** layer | ADR-0009 |
 | Agent orchestration | Role/tier abstraction (`orchestrator`/`executor`/`reviewer`), model mapping in `.claude/settings.json` (generic, drift-free) | ADR-0006 |
 | PR autonomy | Agent opens PRs & drives CI to green; the human owns the merge | ADR-0012 |
+| PR-triggered CI | `pull_request` on secret-free CI only; no secrets in PR-triggered workflows; `pull_request_target` banned | ADR-0013 |
 | Docs SSOT & concision | Docs point to one home, never restate; prose earns its space | `docs/conventions.md` |
 | Agent session capture | Adopt Entire / Checkpoints — scaffold now, activate locally | ADR-0007 |
 | Multi-agent plan validation | Single `tech-architect` agent (no 4-agent panel) | — |
@@ -146,7 +147,7 @@ Urgent: current versions are frozen at end-2023 and accrue CVEs.
 - Enable Docker Scout CVE monitoring *(#100)*
 
 ### Phase 4 — CI/CD hardening & code quality *(P1)* — folds in #103, #104
-- Add `pull_request` trigger to `lint-dockerfile` and `build-test` *(#103, closes #46)*
+- Add `pull_request` trigger to `lint-dockerfile` and `build-test` — **done, ADR-0013** *(#103, closes #46)*
 - Add `concurrency:` to every workflow (cancel stale runs) *(#103)*
 - Harmonise buildx `cache-from` / `cache-to` across workflows *(#103)*
 - Restrict multi-arch build (`amd64,arm64,arm/v7,386`) to publish workflows only *(#103)*


### PR DESCRIPTION
## Summary

Replaces the branch-push triggers of `lint-dockerfile` and `build-test` with
**`pull_request` triggers** — every PR, **including fork contributions** (which
never ran a single CI build before review), is now lint- and build-verified on
the **merge result**, with **full coverage**: all supported versions × all
platforms (maintainer decision — no coverage reduction on the PR path).

**Security boundary (ADR-0013, security-reviewed):**
- `pull_request` fork runs get **no secrets and a read-only `GITHUB_TOKEN`** by
  GitHub's design — nothing to exfiltrate even if the PR modifies the workflow
  file itself.
- These CI workflows stay **secret-free forever**; the publication fix (#100)
  and any secret-consuming step live only in push-to-`master` workflows.
- **`pull_request_target` is banned** (the "pwn request" class).
- Explicit `permissions: contents: read` + `concurrency` (cancels superseded
  runs) on both workflows.

**Trade-off (accepted):** a branch pushed without a PR no longer runs build CI —
opening the PR is the flow (ADR-0012), and one PR run replaces the former
push+PR double-run.

**Maintainer side (goes with this PR):** Settings → Actions → require approval
for outside collaborators' workflow runs — the compute-abuse gate for
full-coverage fork runs.

**Validation:** this PR itself exercises the new trigger — `build-test`'s new
`pull_request` path fires on this very PR (workflow file is in its own paths),
running the full matrix under real PR conditions before merge.

Roadmap phase / closes: CI/CD work of epic #103 — **closes #46**

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (link: `docs/adr/0013-pr-triggered-ci-security-boundary.md`)
- [ ] This PR is **not** a structural change — no ADR needed

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeiH1ZwZE7UUYEE1tjKRrm)_