### PR TITLE
fix(publish): point image identity to the bgauduch namespace

### DIFF
--- a/.github/workflows/dockerhub-description-update.yml
+++ b/.github/workflows/dockerhub-description-update.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PAT }}
-          repository: zenika/terraform-aws-cli
+          repository: bgauduch/terraform-aws-cli

--- a/.github/workflows/push-latest.yml
+++ b/.github/workflows/push-latest.yml
@@ -46,7 +46,7 @@ jobs:
           build-args: |
             TERRAFORM_VERSION=${{ env.TF_VERSION }}
             AWS_CLI_VERSION=${{ env.AWS_VERSION }}
-          tags: zenika/terraform-aws-cli:latest
+          tags: bgauduch/terraform-aws-cli:latest
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,7 +56,7 @@ jobs:
       matrix: ${{ fromJSON(needs.load_supported_versions.outputs.matrix) }}
 
     env:
-      ORGANIZATION: "zenika"
+      ORGANIZATION: "bgauduch"
       IMAGE_NAME: "terraform-aws-cli"
       RELEASE_VERSION: ${{ needs.release-please.outputs.tag_name }}
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,17 @@
 
 [![dockerhub-description-update](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Docker Pulls](https://img.shields.io/docker/pulls/bgauduch/terraform-aws-cli.svg)](https://hub.docker.com/r/bgauduch/terraform-aws-cli/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/bgauduch/terraform-aws-cli.svg?label=pulls)](https://hub.docker.com/r/bgauduch/terraform-aws-cli/)
+[![Docker Pulls (legacy zenika)](https://img.shields.io/docker/pulls/zenika/terraform-aws-cli.svg?label=pulls%20%28legacy%20zenika%29&color=inactive)](https://hub.docker.com/r/zenika/terraform-aws-cli/)
 
 # Terraform and AWS CLI Docker image
+
+> **📦 New registry — please migrate.** This image now lives at
+> [`bgauduch/terraform-aws-cli`](https://hub.docker.com/r/bgauduch/terraform-aws-cli).
+> The legacy [`zenika/terraform-aws-cli`](https://hub.docker.com/r/zenika/terraform-aws-cli)
+> repository is frozen: update your `docker pull` / `FROM` references to the new
+> one. Historical tags are being copied across, migration in progress — see
+> [#137](https://github.com/bgauduch/terraform-aws-cli/issues/137).
 
 ## 📦 Supported tags and respective Dockerfile links
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,27 @@
-[![lint-dockerfile](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/lint-dockerfile.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/lint-dockerfile.yml)
-[![build-test](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/build-test.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/build-test.yml)
-[![push-latest](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/push-latest.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/push-latest.yml)
-[![release-please](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/release-please.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/release-please.yml)
+[![lint-dockerfile](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/lint-dockerfile.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/lint-dockerfile.yml)
+[![build-test](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/build-test.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/build-test.yml)
+[![push-latest](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/push-latest.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/push-latest.yml)
+[![release-please](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/release-please.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/release-please.yml)
 
-[![dockerhub-description-update](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml/badge.svg)](https://github.com/zenika-open-source/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml)
+[![dockerhub-description-update](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Docker Pulls](https://img.shields.io/docker/pulls/zenika/terraform-aws-cli.svg)](https://hub.docker.com/r/zenika/terraform-aws-cli/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/bgauduch/terraform-aws-cli.svg)](https://hub.docker.com/r/bgauduch/terraform-aws-cli/)
 
 # Terraform and AWS CLI Docker image
 
 ## 📦 Supported tags and respective Dockerfile links
 
-Available image tags can be found on the Docker Hub registry: [zenika/terraform-aws-cli](https://hub.docker.com/r/zenika/terraform-aws-cli/tags)
+Available image tags can be found on the Docker Hub registry: [bgauduch/terraform-aws-cli](https://hub.docker.com/r/bgauduch/terraform-aws-cli/tags)
 
-Supported versions are listed in the [`supported_versions.json`](https://github.com/Zenika/terraform-aws-cli/blob/master/supported_versions.json) file.
+Supported versions are listed in the [`supported_versions.json`](https://github.com/bgauduch/terraform-aws-cli/blob/master/supported_versions.json) file.
 
 The following image tag strategy is applied:
 
-* `zenika/terraform-aws-cli:latest` - build from master
-  * Included CLI versions are the latest in [`supported_versions.json`](https://github.com/Zenika/terraform-aws-cli/blob/master/supported_versions.json) file.
-* `zenika/terraform-aws-cli:release-S.T_terraform-UU.VV.WW_awscli-XX.YY.ZZ` - build from releases
-  * `release-S.T` is the release tag
-  * `terraform-UU.VV.WWW` is the **Terraform** version included in the image
-  * `awscli-XX.YY.ZZ` is the **AWS CLI** version included in the image
+* `bgauduch/terraform-aws-cli:latest` — built from master, with the latest versions in [`supported_versions.json`](https://github.com/bgauduch/terraform-aws-cli/blob/master/supported_versions.json).
+* `bgauduch/terraform-aws-cli:vX.Y.Z` — a release, with its latest Terraform and AWS CLI versions.
+* `bgauduch/terraform-aws-cli:vX.Y.Z_tf-A.B.C_aws-D.E.F` — a release, fully pinned to a Terraform (`A.B.C`) and AWS CLI (`D.E.F`) version combination.
 
-Please report to the [releases page](https://github.com/Zenika/terraform-aws-cli/releases) for the changelogs.
+Please report to the [releases page](https://github.com/bgauduch/terraform-aws-cli/releases) for the changelogs.
 
 > Any other tags are not supported even if available.
 
@@ -56,7 +53,7 @@ echo AWS_ACCESS_KEY_ID=YOUR_ACCESS_KEY
 echo AWS_SECRET_ACCESS_KEY=YOUR_SECRET_KEY
 echo AWS_DEFAULT_REGION=YOUR_DEFAULT_REGION
 
-docker container run -it --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" -v ${PWD}:/workspace zenika/terraform-aws-cli:latest
+docker container run -it --rm -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" -v ${PWD}:/workspace bgauduch/terraform-aws-cli:latest
 ```
 
 > The `--rm` flag will completely destroy the container and its data on exit.
@@ -68,7 +65,7 @@ The image can be built locally directly from the Dockerfiles, using the build sc
 It will :
 
 * Lint the Dockerfile with [Hadolint](https://github.com/hadolint/hadolint);
-* Build and tag the image `zenika/terraform-aws-cli:dev`;
+* Build and tag the image `bgauduch/terraform-aws-cli:dev`;
 * Execute [container structure tests](https://github.com/GoogleContainerTools/container-structure-test) on the image.
 
 ```bash
@@ -91,7 +88,7 @@ TERRAFORM_VERSION=1.5.2
 
 Before contributing, please read the [contributing guide](CONTRIBUTING.md), the [code of conduct](CODE_OF_CONDUCT.md) and the [security policy](SECURITY.md).
 
-Do not hesitate to contribute by [filling an issue](https://github.com/Zenika/terraform-aws-cli/issues) or [a PR](https://github.com/Zenika/terraform-aws-cli/pulls) !
+Do not hesitate to contribute by [filling an issue](https://github.com/bgauduch/terraform-aws-cli/issues) or [a PR](https://github.com/bgauduch/terraform-aws-cli/pulls) !
 
 ## 📚 Documentations
 
@@ -107,6 +104,6 @@ Do not hesitate to contribute by [filling an issue](https://github.com/Zenika/te
 * For Azure: [zenika-open-source/terraform-azure-cli](https://github.com/zenika-open-source/terraform-azure-cli)
 
 ## 📖 License
-This project is under the [Apache License 2.0](https://raw.githubusercontent.com/Zenika/terraform-aws-cli/master/LICENSE)
+This project is under the [Apache License 2.0](https://raw.githubusercontent.com/bgauduch/terraform-aws-cli/master/LICENSE)
 
 [![with love by zenika](https://img.shields.io/badge/With%20%E2%9D%A4%EF%B8%8F%20by-Zenika-b51432.svg)](https://oss.zenika.com)

--- a/dev.sh
+++ b/dev.sh
@@ -10,7 +10,7 @@ set -eo pipefail
 [[ -n $2 ]] && TF_VERSION=$2 || TF_VERSION=$(jq -r '.tf_versions | sort | .[-1]' supported_versions.json)
 
 # Set image name and tag (dev if not specified)
-IMAGE_NAME="zenika/terraform-aws-cli"
+IMAGE_NAME="bgauduch/terraform-aws-cli"
 [[ -n $3 ]] && IMAGE_TAG=$3 || IMAGE_TAG="dev"
 
 # Set platform for Hadolint image (only linux/arm64 or linux/arm64 supported)

--- a/docs/binaries-verifications.md
+++ b/docs/binaries-verifications.md
@@ -6,7 +6,7 @@ Both Terraform SHA256SUM and signature files are verified against [Hashicorp pub
 
 Terraform archives are verified against there SHA256SUMS after donwload.
 
-Theses files need to be added to the [/security](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/security) folder.
+Theses files need to be added to the [/security](https://github.com/bgauduch/terraform-aws-cli/tree/master/security) folder.
 
 They can be downloaded from the [official Terraform releases](https://releases.hashicorp.com/terraform).
 
@@ -14,7 +14,7 @@ They can be downloaded from the [official Terraform releases](https://releases.h
 
 Both AWS CLI archives and signatures files are verified against AWS public GPG key.
 
-Theses files need to be added to the [/security](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/security) folder.
+Theses files need to be added to the [/security](https://github.com/bgauduch/terraform-aws-cli/tree/master/security) folder.
 
 They can be downloaded locally using this command:
 

--- a/docs/dependencies-upgrades.md
+++ b/docs/dependencies-upgrades.md
@@ -1,7 +1,7 @@
 # ⬆️ Dependencies upgrades checklist
 
 * Supported tools versions:
-  * [Report to the doc](https://github.com/zenika-open-source/terraform-aws-cli/tree/master/docs/binaries-verifications.md) to add required security files (stored under `security/`, e.g. `security/hashicorp.asc`) when adding a new supported versions
+  * [Report to the doc](https://github.com/bgauduch/terraform-aws-cli/tree/master/docs/binaries-verifications.md) to add required security files (stored under `security/`, e.g. `security/hashicorp.asc`) when adding a new supported versions
   * check available **AWS CLI** version on the [project release page](https://github.com/aws/aws-cli/tags)
   * check available **Terraform CLI** version (keep one patch per minor, from 1.0 — see ADR-0004) on the [project release page](https://github.com/hashicorp/terraform/releases)
 * Dockerfile:

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -29,17 +29,17 @@ meaning). That distinction is what makes rollback safe and predictable.
    reproducibility (CI jobs, base images):
 
    ```dockerfile
-   FROM zenika/terraform-aws-cli:v8.1.0_tf-1.6.5_aws-2.14.5
+   FROM bgauduch/terraform-aws-cli:v8.1.0_tf-1.6.5_aws-2.14.5
    ```
 
 2. To roll back, change the pin to the previous known-good fully-pinned tag:
 
    ```dockerfile
-   FROM zenika/terraform-aws-cli:v8.0.1_tf-1.6.5_aws-2.14.5
+   FROM bgauduch/terraform-aws-cli:v8.0.1_tf-1.6.5_aws-2.14.5
    ```
 
 3. Browse available tags on the
-   [Docker Hub tags page](https://hub.docker.com/r/zenika/terraform-aws-cli/tags)
+   [Docker Hub tags page](https://hub.docker.com/r/bgauduch/terraform-aws-cli/tags)
    and the matching changelog on the
    [GitHub releases page](https://github.com/bgauduch/terraform-aws-cli/releases).
 


### PR DESCRIPTION
## Summary

Publication has been **broken since the repo migration**: the workflows still
push to `zenika/terraform-aws-cli`, so the newly configured `bgauduch`
credentials log in successfully but **cannot push** (403 — no rights on the
`zenika` namespace). This PR renames the image and repository references to
`bgauduch/terraform-aws-cli`, which both **cleans up the stale references** and
**unblocks publication** — one coherent unit. It also adds a **user-facing
migration notice** so users of the legacy repository know to move.

**Changes**
- **Workflows:** `push-latest` image tag, `release-please` `ORGANIZATION` var,
  `dockerhub-description-update` `repository`.
- **`dev.sh`** `IMAGE_NAME`; **README** badges, Docker Hub links, usage example
  and dev image name; **`docs/rollback.md`**, **`docs/binaries-verifications.md`**,
  **`docs/dependencies-upgrades.md`** links (incl. old `zenika-open-source` /
  `Zenika` GitHub URLs → `bgauduch`).
- **README tag strategy:** replaced the stale `release-S.T_terraform-...` scheme
  with the one actually published by `release-please.yml` (`latest`, `vX.Y.Z`,
  `vX.Y.Z_tf-A.B.C_aws-D.E.F`), per ADR-0003.
- **Registry-migration notice (README):** a banner marking `bgauduch/...` the new
  home and `zenika/...` frozen, asking users to update `docker pull` / `FROM`
  references (tracked in #137). Plain markdown so it also renders on the Docker
  Hub description (synced from README). The legacy `zenika` Docker Pulls badge is
  **kept** (greyed, "legacy zenika") next to the new one so historical adoption
  stays visible during the transition.

**Kept intentionally** (out of scope — origin attribution, not stale refs): the
Azure sibling link (`zenika-open-source/terraform-azure-cli`, a separate live
project) and the "with love by zenika" attribution badge.

**Publication test:** this PR touches `push-latest.yml` (in its own path
filter), so **merging it triggers `push-latest` on `master`** → the first
`bgauduch/terraform-aws-cli:latest` publish (multi-arch, TF 1.6.5 + AWS 2.14.5).
The merge is maintainer-owned (ADR-0012).

**Follow-ups (this PR does not include them):** `docker/login-action` + GHCR
(#100, closes #60); full tag strategy + the jq lexicographic-sort fix (#100);
the historical-tag migration (#137). The `dockerhub-description@v3` action may
need a v4 bump if it rejects the PAT — tracked separately.

Roadmap phase / closes: Phase 3 — image distribution — relates #100 #137

## Architecture Decision Record

This PR touches structural paths (workflows) but **implements existing
decisions** — the naming migration (#100) and the tag scheme (ADR-0003). It
records no new decision; `adr-not-needed` applies.

- [ ] This PR adds/updates an ADR under `docs/adr/`
- [x] Implements existing decisions (#100, ADR-0003) — `adr-not-needed`, no new decision

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope