### PR TITLE
ci: split the DockerHub description token from the image-publish token

### DIFF
--- a/.github/workflows/dockerhub-description-update.yml
+++ b/.github/workflows/dockerhub-description-update.yml
@@ -16,8 +16,11 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Update Docker Hub Description
+        # Dedicated Read/Write/Delete token: the description PATCH endpoint requires
+        # Delete scope, which the image-publish token (DOCKERHUB_PAT, Read/Write) must
+        # not carry. Least-privilege split — keeps Delete off the publish path (#100).
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PAT }}
+          password: ${{ secrets.DOCKERHUB_DESCRIPTION_PAT }}
           repository: bgauduch/terraform-aws-cli

--- a/.github/workflows/dockerhub-description-update.yml
+++ b/.github/workflows/dockerhub-description-update.yml
@@ -16,9 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Update Docker Hub Description
-        # Dedicated Read/Write/Delete token: the description PATCH endpoint requires
-        # Delete scope, which the image-publish token (DOCKERHUB_PAT, Read/Write) must
-        # not carry. Least-privilege split — keeps Delete off the publish path (#100).
+        # Dedicated Read/Write/Delete token — registry auth model: docs/publishing.md.
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Do not hesitate to contribute by [filling an issue](https://github.com/bgauduch/
 * [Contributing guide](CONTRIBUTING.md)
 * [Code of conduct](CODE_OF_CONDUCT.md)
 * [Security policy](SECURITY.md)
+* [Publishing & registry auth](docs/publishing.md)
 * [Rollback policy](docs/rollback.md)
 * [Dependencies upgrades checklist](docs/dependencies-upgrades.md)
 * [Binaries verifications](docs/binaries-verifications.md)

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,35 @@
+# Publishing
+
+How the image is built, published, and authenticated. The user-facing tag list
+lives in the [`README`](../README.md#-supported-tags-and-respective-dockerfile-links);
+the tag scheme rationale is [ADR-0003](adr/0003-image-tag-strategy.md).
+
+## Registries
+
+- **Docker Hub** — `bgauduch/terraform-aws-cli` (primary). The legacy
+  `zenika/terraform-aws-cli` is frozen; tag migration is tracked in #137.
+- **GHCR** — planned as a second registry (#100).
+
+## Workflows
+
+- **`push-latest`** — builds and pushes `:latest` (multi-arch) on every relevant
+  push to `master`.
+- **`release-please`** — on a release, builds the version and fully-pinned tags.
+- **`dockerhub-description-update`** — syncs the Docker Hub description from
+  `README.md`.
+
+## Registry authentication
+
+Credentials are GitHub repository secrets (values live in **Settings → Secrets**,
+never in the repo). Scopes follow least privilege — the token that pushes images
+never carries `Delete`:
+
+| Secret | Docker Hub scope | Used by | Why |
+|--------|------------------|---------|-----|
+| `DOCKERHUB_USERNAME` | — | all three | account name |
+| `DOCKERHUB_PAT` | Read & Write | `push-latest`, `release-please` | push image tags |
+| `DOCKERHUB_DESCRIPTION_PAT` | Read, Write & Delete | `dockerhub-description-update` | the description API rejects tokens without `Delete` |
+
+The `Delete`-scoped token exists only for the description update and appears only
+in this push-to-`master` workflow — never in a `pull_request`-triggered one, per
+[ADR-0013](adr/0013-pr-triggered-ci-security-boundary.md).

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,35 +1,22 @@
 # Publishing
 
-How the image is built, published, and authenticated. The user-facing tag list
-lives in the [`README`](../README.md#-supported-tags-and-respective-dockerfile-links);
-the tag scheme rationale is [ADR-0003](adr/0003-image-tag-strategy.md).
+Authentication for the image-publishing workflows. What each workflow publishes
+and which secret it consumes is defined in the workflows themselves
+([`.github/workflows/`](../.github/workflows/)); the user-facing tags are in the
+[README](../README.md#-supported-tags-and-respective-dockerfile-links) (scheme:
+[ADR-0003](adr/0003-image-versioning-and-tag-strategy.md)). This page is the single home for the
+**credential model** only.
 
-## Registries
+## Registry credentials (least privilege)
 
-- **Docker Hub** — `bgauduch/terraform-aws-cli` (primary). The legacy
-  `zenika/terraform-aws-cli` is frozen; tag migration is tracked in #137.
-- **GHCR** — planned as a second registry (#100).
+Credentials are GitHub repository secrets (values live in **Settings → Secrets**).
+Scopes stay minimal so the token that pushes images never carries `Delete`:
 
-## Workflows
+| Secret | Docker Hub scope | For |
+|--------|------------------|-----|
+| `DOCKERHUB_USERNAME` | — | account name |
+| `DOCKERHUB_PAT` | Read & Write | pushing image tags |
+| `DOCKERHUB_DESCRIPTION_PAT` | Read, Write & Delete | the description API, which rejects tokens without `Delete` |
 
-- **`push-latest`** — builds and pushes `:latest` (multi-arch) on every relevant
-  push to `master`.
-- **`release-please`** — on a release, builds the version and fully-pinned tags.
-- **`dockerhub-description-update`** — syncs the Docker Hub description from
-  `README.md`.
-
-## Registry authentication
-
-Credentials are GitHub repository secrets (values live in **Settings → Secrets**,
-never in the repo). Scopes follow least privilege — the token that pushes images
-never carries `Delete`:
-
-| Secret | Docker Hub scope | Used by | Why |
-|--------|------------------|---------|-----|
-| `DOCKERHUB_USERNAME` | — | all three | account name |
-| `DOCKERHUB_PAT` | Read & Write | `push-latest`, `release-please` | push image tags |
-| `DOCKERHUB_DESCRIPTION_PAT` | Read, Write & Delete | `dockerhub-description-update` | the description API rejects tokens without `Delete` |
-
-The `Delete`-scoped token exists only for the description update and appears only
-in this push-to-`master` workflow — never in a `pull_request`-triggered one, per
-[ADR-0013](adr/0013-pr-triggered-ci-security-boundary.md).
+The `Delete`-scoped token is used only by the push-to-`master` description
+workflow, never in a `pull_request`-triggered one ([ADR-0013](adr/0013-pr-triggered-ci-security-boundary.md)).


### PR DESCRIPTION
## Summary

Least-privilege split of the DockerHub credentials, **plus documentation of the
publishing/auth model**. The `peter-evans/dockerhub-description` PATCH endpoint
requires a **Read, Write & Delete**-scoped token, whereas image publishing only
needs **Read & Write**. Sharing a single `DOCKERHUB_PAT` forced the **publish**
token to carry `Delete`.

**Changes**
- `dockerhub-description-update.yml` → dedicated **`DOCKERHUB_DESCRIPTION_PAT`**
  (Read/Write/Delete), so `DOCKERHUB_PAT` stays **Read/Write** for `push-latest`
  / `release-please` and the image-publish token never carries `Delete`. The
  Delete-scoped token lives only in this push-to-`master` workflow, never in a
  `pull_request`-triggered one (ADR-0013).
- New **`docs/publishing.md`** — single home for the publishing model and the
  registry-auth secrets (which secret, what scope, which workflow, why). Points
  to GitHub for the live values (L3) and to the README for the user-facing tags.

### ⚠️ Maintainer prerequisite — order matters (avoids re-breaking the description)

1. **Before merge:** create repo secret **`DOCKERHUB_DESCRIPTION_PAT`** with
   **Read, Write & Delete** scope. ✅ *(done — confirmed 2026-07-23)*
2. Merge this PR → the description update authenticates with the new token.
3. **After merge:** downgrade **`DOCKERHUB_PAT`** back to **Read & Write** only
   (it was temporarily widened to Delete to green the description) — this is what
   actually removes `Delete` from the publish path.

(`dockerhub-description@v3` also trips the Node-20 deprecation — the v4 bump is
tracked with the Actions bumps in #98, out of scope here.)

Roadmap phase / closes: Phase 3 — distribution — relates #100 #99

## Architecture Decision Record

Workflow change + supporting doc, but a **least-privilege refinement**, not a new
decision — the secret-in-workflow boundary is already set by ADR-0013.
`adr-not-needed`.

- [ ] This PR adds/updates an ADR under `docs/adr/`
- [x] Least-privilege refinement under ADR-0013 — `adr-not-needed`, no new decision

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope