### PR TITLE
ci: cancel superseded adr-check runs to fix the label race

### DIFF
--- a/.github/workflows/adr-check.yml
+++ b/.github/workflows/adr-check.yml
@@ -12,6 +12,13 @@ permissions:
   contents: read
   pull-requests: read
 
+# Cancel a superseded run for the same PR. Without this, the label-free `opened`
+# run can finish after the `labeled` run and flip the check red (a scheduling
+# race). Grouping per PR + cancel-in-progress keeps only the latest run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   adr-check:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

`adr-check` triggers on `opened` / `labeled` / `unlabeled` / `synchronize` and
reads the label set from the **event payload**. GitHub can schedule the
label-free `opened` run so it finishes **after** the `labeled` run, flipping the
required check **red** even though the `adr-not-needed` label is present — a pure
scheduling race (hit on **#141** and **#143**, each needing a manual label toggle
to recover).

Add a per-PR `concurrency` group with `cancel-in-progress: true` so a newer event
**cancels** the stale in-flight run instead of letting it complete and override
the result. This matches the pattern already on `commitlint` and `build-test`
(`adr-check` was the only PR-triggered workflow missing it).

**Why it matters now:** it's a prerequisite for making `adr-check` a **required**
check (#103) — otherwise the race would block real PRs, not just annoy.

**Publish workflows intentionally excluded:** `push-latest` / `release-please`
must not get `cancel-in-progress` (it could abort a publish mid-run).

Roadmap phase / closes: Phase 4 — CI/CD hardening — relates #103

## Architecture Decision Record

Workflow reliability tweak, not a structural decision — the ADR gate itself is
unchanged. `adr-not-needed`.

- [ ] This PR adds/updates an ADR under `docs/adr/`
- [x] CI reliability refinement — `adr-not-needed`, no new decision

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeiH1ZwZE7UUYEE1tjKRrm)_