### PR TITLE
fix(agent): load binding docs into agent context at session start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # CLAUDE.md
 
-Claude Code adapter (ADR-0009). Read [`AGENTS.md`](AGENTS.md) first — the
-tool-agnostic source of truth for working this repo. `.claude/` holds the Claude
+Claude Code adapter (ADR-0009). The imports below load the binding docs into
+every session's context before any edit — `AGENTS.md` and the docs it points to
+stay the single homes (nothing is restated here). `.claude/` holds the Claude
 Code settings (adapter layer). Keep instructions in `AGENTS.md`, not here.
+
+@AGENTS.md
+
+@docs/conventions.md
+
+@docs/adr/README.md

--- a/docs/adr/0009-agent-agnostic-framework.md
+++ b/docs/adr/0009-agent-agnostic-framework.md
@@ -9,6 +9,16 @@
 > boundaries, roles) live in `AGENTS.md` itself, per the AGENTS.md standard. The
 > core/adapter split below is unchanged.
 
+> **Amended 2026-07-23** — the thin `CLAUDE.md` adapter now *imports*
+> (`@AGENTS.md`, `@docs/conventions.md`, `@docs/adr/README.md`) instead of only
+> linking: Claude Code loads imports into the session context at start, so the
+> binding rules reach the agent before any edit. A link had proven insufficient
+> (an agent skipped it and fell back on generic defaults). Likewise the
+> SessionStart hook prints its resume pointer on **stdout** — hook stdout is
+> injected into the agent's context, stderr is user-only, so the pointer was
+> previously invisible to agents. The core/adapter split is unchanged; another
+> tool's adapter would use its own equivalent loading mechanism.
+
 ## Context and problem statement
 
 The framework was authored around "Claude" — naming ("Claude Code framework",

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -12,7 +12,9 @@ AGENTS.md ─────────────► agent entry point + session
   ├─ docs/roadmap.md             the plan
   └─ docs/adr/                   the decisions + rationale
 
-CLAUDE.md ─────────────► thin Claude Code adapter → AGENTS.md
+CLAUDE.md ─────────────► thin Claude Code adapter — imports AGENTS.md,
+  │                       docs/conventions.md and docs/adr/README.md into the
+  │                       session context at start (ADR-0009, amended)
   └─ .claude/{settings.json, README.md}   hook wiring + role→model map + perms
 
 scripts/agent-session-start.sh ► agnostic bootstrap (reused by the adapter)

--- a/scripts/agent-session-start.sh
+++ b/scripts/agent-session-start.sh
@@ -9,7 +9,9 @@
 # What it does (idempotent, non-interactive):
 #   1. Starts the Docker daemon behind the egress proxy, with the proxy CA
 #      trusted, if a daemon is not already running.
-#   2. Prints a "resume here" pointer to the sources of truth.
+#   2. Prints a "resume here" pointer on stdout. For SessionStart hooks stdout
+#      is injected into the agent's context; stderr is user-only diagnostics —
+#      anything the agent must see MUST go to stdout.
 #
 # The full multi-arch image build stays in CI; locally this unblocks lint,
 # base-image pulls, pin installs and the version assertions — the checks that
@@ -46,14 +48,19 @@ else
   log "docker CLI not found — skipping daemon bootstrap"
 fi
 
-# 2) Resume pointer — where the plan and live status live.
-cat >&2 <<'PTR'
-[agent-session-start] Resume here:
-  * tracking issue #106  — live status, open PRs/issues, next actions (status SSOT)
-  * AGENTS.md            — rules entry point (-> docs/conventions.md)
-  * docs/roadmap.md      — the plan (phases, decisions)
-  * docs/adr/            — the decisions and their rationale
-  Local image verify recipe (Debian/version bumps): docs/agent-framework.md
+# 2) Resume pointer — stdout, so it lands in the agent's context. The binding
+#    rules themselves are already loaded via the CLAUDE.md imports (AGENTS.md,
+#    docs/conventions.md, docs/adr/README.md) — only point at what imports
+#    cannot cover: the live status and the plan.
+cat <<'PTR'
+Resume here — before any change:
+  * The session rules, working conventions and the ADR requirement are already
+    in your context (imported by CLAUDE.md). They are binding and take
+    precedence over any generic agent default.
+  * Tracking issue #106 — live status, open PRs/issues, next actions (status
+    SSOT). Read it first; keep its body current when state changes.
+  * docs/roadmap.md — the plan (phases, decisions).
+  * Local image verify recipe (Debian/version bumps): docs/agent-framework.md
 PTR
 
 exit 0


### PR DESCRIPTION
## Summary

Guarantee that the binding docs reach every agent's context **before any edit**, fixing two holes found by auditing a live session where an agent skipped `docs/conventions.md` and fell back on generic defaults (e.g. not opening a PR, per its harness default, against ADR-0012):

1. **`CLAUDE.md` now imports instead of linking.** `@AGENTS.md`, `@docs/conventions.md` and `@docs/adr/README.md` are expanded into the session context at start (native Claude Code mechanism, [documented](https://code.claude.com/docs/en/memory#import-additional-files) as the recommended pattern for AGENTS.md repos). A link can be skipped; an import cannot. No duplication — the imported files remain the single homes (L2), the adapter stays thin (ADR-0009). Loaded budget: ~200 lines total, within the recommended size.
2. **The SessionStart hook printed its "resume here" pointer to stderr — which agents never see.** Per the [hooks reference](https://code.claude.com/docs/en/hooks), SessionStart **stdout** is injected into the agent's context while **stderr** is user-only diagnostics. The pointer now goes to stdout, trimmed to what imports cannot cover: the live status SSOT (#106), the roadmap, and the verify recipe. Docker bootstrap diagnostics stay on stderr. Verified locally by running the hook and checking each stream.

`docs/roadmap.md` (plan, not rules) is deliberately **not** imported — pointed at instead, to keep the loaded context lean.

Roadmap phase / closes: agent framework hardening (ADR-0009 clarification) — no phase item; follow-up to the framework work of #134/#136.

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (link: [ADR-0009, dated amend note](docs/adr/0009-agent-agnostic-framework.md))
- [ ] This PR is **not** a structural change — no ADR needed

Clarification of the existing adapter decision, not a reversal → dated amend on ADR-0009 per `docs/adr/README.md` ("clarification → amend").

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed (ADR-0009 amend + `docs/agent-framework.md` map)
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rDj6RYgytd45tiR7M8uh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1rDj6RYgytd45tiR7M8uh)_