### PR TITLE
docs(conventions): add D5 status-upkeep and L5 comment rules, drop dated notes

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,9 +24,8 @@ A pure version bump, a typo fix, or a docs tweak does **not** need an ADR.
 An ADR records a **durable decision with a real trade-off** that is costly to
 reverse — something a future contributor will ask *why?* about. A **reversible
 convention or style choice** (a naming detail, a doc-style rule) does **not**
-meet the requirement: it lives in [`docs/conventions.md`](../conventions.md)
-with a dated amend note. When other docs cite "the ADR requirement", they mean
-this section.
+meet the requirement: it lives in [`docs/conventions.md`](../conventions.md).
+When other docs cite "the ADR requirement", they mean this section.
 
 ## How it is enforced
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -12,9 +12,9 @@ Agent-session rules (authorization boundaries, roles) live in
   Advisory guidance lives in `docs/` or an ADR, not here.
 - No judgement words; `NEVER` / `ALWAYS` / `MAY` mark the binding verbs.
 - Evolutions: append to the relevant section — per-section numbers (B1, C2, …)
-  never shift; amend with a dated note; new rules arrive via the learning
-  pipeline (L4). Durable records (ADRs) reference rules **by concept**, not by
-  number.
+  never shift; git history is the change record; new rules arrive via the
+  learning pipeline (L4). Durable records (ADRs) reference rules **by
+  concept**, not by number.
 - If this file outgrows quick scanning (~150 lines), split it into
   `docs/conventions/` (one file per section) — as an explicit, separate change.
 
@@ -52,7 +52,7 @@ Agent-session rules (authorization boundaries, roles) live in
 - **D5 — A state change ships with its status update.** Opening, merging or
   closing a PR — or completing a tracked task — edits the tracking issue (#106)
   body in the same gesture; epic/phase checklists are ticked when the
-  delivering PR merges. *(Added 2026-07-23.)*
+  delivering PR merges.
 
 ## ADRs
 
@@ -71,6 +71,6 @@ Agent-session rules (authorization boundaries, roles) live in
 - **L3 — `NEVER` mirror mutable infra/UI settings in prose.** Reference the
   GitHub config; decisions about them live in ADRs, live values in GitHub.
 - **L4 — Learnings graduate to a durable home.** Captured transiently in the
-  tracking issue (#106), then promoted: a rule here (with a dated note) for a
+  tracking issue (#106), then promoted: a rule here for a
   do/don't, an ADR for a decision meeting the ADR requirement. #106 keeps only
   live status and not-yet-graduated learnings.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -49,6 +49,11 @@ Agent-session rules (authorization boundaries, roles) live in
 - **D4 — A PR's title and description track its current content.** When new
   commits change what the PR delivers, update both in the same pass (the
   title's downstream role: C1).
+- **D5 — A state change ships with its status update, unprompted.** Opening,
+  merging or closing a PR — or completing a tracked task — edits the tracking
+  issue (#106) body in the same gesture; epic/phase checklists are ticked when
+  the delivering PR merges. *(Added 2026-07-23, graduated from the tracking
+  issue's learnings.)*
 
 ## ADRs
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -74,3 +74,7 @@ Agent-session rules (authorization boundaries, roles) live in
   tracking issue (#106), then promoted: a rule here for a
   do/don't, an ADR for a decision meeting the ADR requirement. #106 keeps only
   live status and not-yet-graduated learnings.
+- **L5 — Code comments state only what the code cannot show.** A comment
+  records a constraint or non-obvious behaviour, tersely; incident context,
+  versions and narration belong in commits, PRs and docs. `NEVER` em or en
+  dashes in code comments.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -52,8 +52,7 @@ Agent-session rules (authorization boundaries, roles) live in
 - **D5 — A state change ships with its status update.** Opening, merging or
   closing a PR — or completing a tracked task — edits the tracking issue (#106)
   body in the same gesture; epic/phase checklists are ticked when the
-  delivering PR merges. *(Added 2026-07-23, graduated from the tracking
-  issue's learnings.)*
+  delivering PR merges. *(Added 2026-07-23.)*
 
 ## ADRs
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -49,10 +49,10 @@ Agent-session rules (authorization boundaries, roles) live in
 - **D4 — A PR's title and description track its current content.** When new
   commits change what the PR delivers, update both in the same pass (the
   title's downstream role: C1).
-- **D5 — A state change ships with its status update, unprompted.** Opening,
-  merging or closing a PR — or completing a tracked task — edits the tracking
-  issue (#106) body in the same gesture; epic/phase checklists are ticked when
-  the delivering PR merges. *(Added 2026-07-23, graduated from the tracking
+- **D5 — A state change ships with its status update.** Opening, merging or
+  closing a PR — or completing a tracked task — edits the tracking issue (#106)
+  body in the same gesture; epic/phase checklists are ticked when the
+  delivering PR merges. *(Added 2026-07-23, graduated from the tracking
   issue's learnings.)*
 
 ## ADRs


### PR DESCRIPTION
## Summary

Three conventions changes, all graduated from this session's review feedback (L4 pipeline):

1. **New Delivery rule D5 — status updates ship with the state change**: opening, merging or closing a PR, or completing a tracked task, edits the tracking issue (#106) body in the same gesture; epic/phase checklists are ticked when the delivering PR merges. Binds every contributor; lives with D1–D4, auto-loaded into agent context since #146.
2. **New Language rule L5 — code comments state only what the code cannot show**: a comment records a constraint or non-obvious behaviour, tersely; incident context, versions and narration belong in commits, PRs and docs. Em/en dashes banned in code comments (mechanically greppable, enables a future CI gate).
3. **Dated-note convention dropped for rule evolutions**: git history is the change record; the meta-rule, L4 and the `docs/adr/README.md` pointer are updated consistently. ADRs keep their own dated amend notes.

Review iterations folded in: "unprompted" dropped from D5 (redundant, read agent-specific).

Roadmap phase / closes: docs graduation (L4) — executes the "next docs PR" item of #106.

## Architecture Decision Record

- [ ] This PR adds/updates an ADR under `docs/adr/` (link: ____)
- [x] This PR is **not** a structural change — no ADR needed

Reversible working-convention changes — per `docs/adr/README.md` these live in `docs/conventions.md`, not in an ADR.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1rDj6RYgytd45tiR7M8uh