### PR TITLE
docs: add ADR-0014 work intake and triage process

### DIFF
--- a/docs/adr/0014-work-intake-and-triage-process.md
+++ b/docs/adr/0014-work-intake-and-triage-process.md
@@ -1,0 +1,85 @@
+# 0014 — Work intake and triage process (features, fixes, contributions)
+
+- Status: Accepted
+- Date: 2026-07-24
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+Work enters the repository from several doors — a maintainer idea, a bug, an
+external contribution — with no shared lifecycle between "an idea appears" and
+"a branch is delivered". The Renovate custom-manager work is the worked example
+of what goes wrong: it was qualified in epic #102, folded into the roadmap, then
+**epic #102 was closed as *completed* while its custom-manager sub-task was never
+delivered**. The scope survived only because it was re-homed by hand to #20 and
+#106 after the fact. Without an explicit intake pipeline, scope leaks silently,
+duplicates get re-studied, and out-of-scope work slips in.
+
+## Decision drivers
+
+- No silent scope leaks: nothing is closed as done while part of it is undelivered.
+- Deduplicate before creating: the same idea should not be studied twice.
+- Keep the product scope tight: an explicit go/nogo gate, not implicit accretion.
+- One home per fact (conventions L2): each item has a durable home for its
+  qualified spec, its priority, and its plan.
+- Repeatable by humans and agents alike, and cheap enough that a typo fix is not
+  forced through five phases.
+
+## Considered options
+
+- **Ad-hoc (status quo)** — ideas become issues/PRs whenever, closed by feel.
+  *Rejected — this is exactly what leaked the #102 sub-task.*
+- **Heavyweight external board / project-management tool.** *Rejected — overkill
+  for a low-traffic single-maintainer OSS repo; another surface to keep in sync.*
+- **A lightweight five-phase intake pipeline, homed in a reference doc and
+  governed by this ADR.** Chosen.
+
+## Decision outcome
+
+Chosen option: **a five-phase intake pipeline** that every non-trivial unit of
+work flows through. The phases are the decision; the operational checklist is
+[`docs/work-intake-and-triage.md`](../work-intake-and-triage.md).
+
+1. **Deduplication** — search existing issues, PRs, ADRs and the roadmap before
+   anything else; link and defer to the existing home if found.
+2. **Study & framing** — analyse, qualify, ideate; a **go/nogo gate** answers *is
+   it useful?* and *does it stay in product scope?*. A `go` creates the issue
+   (the qualified spec); a `nogo` is recorded and closed `not planned`.
+3. **Prioritisation** — rank against other work, identify dependencies, and add
+   it to `docs/roadmap.md` (phase + Decisions table when a decision is made).
+4. **Planning** — validate the plan; surface edge cases and cross-cutting impact
+   on behaviour, docs and process; record the plan in the **issue body** (the
+   issue is the single home for its own spec + plan).
+5. **Realisation** — deliver as one focused PR (delivery conventions D1–D5);
+   may be deferred or delegated over time.
+
+**Closing integrity (the rule that fixes the #102 defect):** an issue or epic is
+`completed` only when its declared scope is delivered. Undelivered scope is
+**re-homed explicitly** (to another tracked issue, with the pointer in place
+*before* closing) or the item stays open. Never closed `completed` with an
+unchecked box and no re-home.
+
+**Scales down:** a typo, a pure version bump, or an obvious one-line fix skips
+straight to realisation — the pipeline binds *net-new features, structural
+changes, and external contributions*, not trivial hygiene.
+
+### Consequences
+
+- Good: scope stops leaking (closing integrity); duplicates are caught before
+  restudy; the go/nogo gate keeps the product minimal; every item has one home
+  for spec, priority and plan.
+- Bad / cost: upfront ceremony per item; mitigated by the scale-down clause and
+  by keeping the reference doc a short checklist, not a process manual.
+- Follow-ups: the operational checklist lives in
+  [`docs/work-intake-and-triage.md`](../work-intake-and-triage.md); a binary
+  *closing-integrity* rule may graduate into `docs/conventions.md` (Delivery) via
+  the learning pipeline if the ADR statement proves too soft in practice; the
+  Renovate custom-manager work (#20) is the first item re-run through this
+  pipeline.
+
+## More information
+
+- Motivating leak: epic #102 (closed `completed`) → re-homed to #20 / #106.
+- Related: `docs/roadmap.md` (prioritisation home), `docs/conventions.md`
+  (Delivery D1–D5, Docs/language L2), ADR-0001 (roadmap + framework as SSOT).
+- The ADR requirement itself: [`docs/adr/README.md`](README.md).

--- a/docs/adr/0014-work-intake-and-triage-process.md
+++ b/docs/adr/0014-work-intake-and-triage-process.md
@@ -49,9 +49,18 @@ work flows through. The phases are the decision; the operational checklist is
    it to `docs/roadmap.md` (phase + Decisions table when a decision is made).
 4. **Planning** — validate the plan; surface edge cases and cross-cutting impact
    on behaviour, docs and process; record the plan in the **issue body** (the
-   issue is the single home for its own spec + plan).
+   issue is the single home for its own spec + plan); resolve the **ADR
+   lifecycle** (below).
 5. **Realisation** — deliver as one focused PR (delivery conventions D1–D5);
    may be deferred or delegated over time.
+
+**ADR lifecycle is not re-specified here.** Creation, amendment, and
+supersession follow the existing ADR process
+([`docs/adr/README.md`](README.md), § Amending vs superseding): a conflict with a
+recorded decision is flagged as early as dedup/study (phase 1–2, a supersede
+candidate) and resolved at planning (phase 4) — new decision → new ADR; reversal
+→ supersede; clarification → amend; reversible convention → `conventions.md`. The
+pipeline hooks into that process rather than duplicating it (conventions L2).
 
 **Closing integrity (the rule that fixes the #102 defect):** an issue or epic is
 `completed` only when its declared scope is delivered. Undelivered scope is

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -85,3 +85,4 @@ Rule of thumb: *clarification → amend; reversal → supersede.*
 | [0011](0011-migrate-base-image-to-debian-trixie.md) | Migrate the base image to Debian 13 (trixie) | Accepted |
 | [0012](0012-agent-opens-and-drives-pull-requests.md) | The agent opens and drives pull requests; the human owns the merge | Accepted |
 | [0013](0013-pr-triggered-ci-security-boundary.md) | PR-triggered CI and its security boundary | Accepted |
+| [0014](0014-work-intake-and-triage-process.md) | Work intake and triage process (features, fixes, contributions) | Accepted |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,6 +72,7 @@ to green; the human owns the merge).
 | PR autonomy | Agent opens PRs & drives CI to green; the human owns the merge | ADR-0012 |
 | PR-triggered CI | `pull_request` on secret-free CI only; no secrets in PR-triggered workflows; `pull_request_target` banned | ADR-0013 |
 | Docs SSOT & concision | Docs point to one home, never restate; prose earns its space | `docs/conventions.md` |
+| Work intake & triage | Five-phase pipeline (dedup → study/go-nogo → prioritise → plan → realise) + closing integrity | ADR-0014 |
 | Agent session capture | Adopt Entire / Checkpoints — scaffold now, activate locally | ADR-0007 |
 | Multi-agent plan validation | Single `tech-architect` agent (no 4-agent panel) | — |
 | End-user persona agents | Two on-demand agents: `end-user-sre-ci`, `end-user-dev-local` | — |

--- a/docs/work-intake-and-triage.md
+++ b/docs/work-intake-and-triage.md
@@ -1,0 +1,53 @@
+# Work intake & triage
+
+Operational checklist for the five-phase intake pipeline decided in
+[ADR-0014](adr/0014-work-intake-and-triage-process.md). The *why* and the phase
+definitions live there; this file is the *how*. It binds net-new features,
+structural changes, and external contributions — trivial hygiene (typos, pure
+version bumps, one-line fixes) skips to phase 5.
+
+## The pipeline
+
+### 1. Deduplication
+- [ ] Search open **and** closed issues/PRs, `docs/adr/`, and `docs/roadmap.md`
+  for the same idea.
+- [ ] If it already has a home: link to it, add context there, and stop. No new
+  issue.
+
+### 2. Study & framing (go/nogo)
+- [ ] Analyse and qualify: problem, users affected, rough approach, alternatives.
+- [ ] **Go/nogo gate** — answer both:
+  - Is it **useful** (real problem, worth the maintenance)?
+  - Does it **stay in product scope** (minimalist Terraform + AWS CLI image)?
+- [ ] `nogo` → record the reasoning, close `not planned` (or decline the PR).
+- [ ] `go` → create the issue: it is the **qualified spec** and its single home.
+
+### 3. Prioritisation
+- [ ] Rank against current work (phase/priority in `docs/roadmap.md`).
+- [ ] Identify dependencies and blockers; link them.
+- [ ] Add to the roadmap (phase line; Decisions table when a decision is taken).
+
+### 4. Planning
+- [ ] Validate the plan (orchestrator review — ADR-0006 roles).
+- [ ] Surface **edge cases** and **cross-cutting impact**: behaviour, docs,
+  process, CI, security.
+- [ ] Record the plan in the **issue body** (edited in place, not scattered in
+  comments).
+- [ ] Structural change? Draft the ADR now (the [ADR requirement](adr/README.md)).
+
+### 5. Realisation
+- [ ] Deliver as one focused PR — delivery conventions D1–D5.
+- [ ] May be deferred or delegated; the issue body carries the plan across sessions.
+
+## Closing integrity
+
+An issue or epic is `completed` **only** when its declared scope is delivered.
+Undelivered scope is **re-homed to a tracked issue with the pointer in place
+before closing**, or the item stays open. Never close `completed` over an
+unchecked box (the failure that stranded the Renovate custom manager in #20).
+
+## Pointers
+
+Prioritisation home: [`docs/roadmap.md`](roadmap.md) · Delivery & language rules:
+[`docs/conventions.md`](conventions.md) · Decisions: [`docs/adr/`](adr/) · Live
+status: tracking issue #106.

--- a/docs/work-intake-and-triage.md
+++ b/docs/work-intake-and-triage.md
@@ -19,6 +19,8 @@ version bumps, one-line fixes) skips to phase 5.
 - [ ] **Go/nogo gate** — answer both:
   - Is it **useful** (real problem, worth the maintenance)?
   - Does it **stay in product scope** (minimalist Terraform + AWS CLI image)?
+- [ ] Flag any **conflict with a recorded decision** (an existing ADR): it is a
+  supersede candidate, resolved at planning.
 - [ ] `nogo` → record the reasoning, close `not planned` (or decline the PR).
 - [ ] `go` → create the issue: it is the **qualified spec** and its single home.
 
@@ -33,7 +35,13 @@ version bumps, one-line fixes) skips to phase 5.
   process, CI, security.
 - [ ] Record the plan in the **issue body** (edited in place, not scattered in
   comments).
-- [ ] Structural change? Draft the ADR now (the [ADR requirement](adr/README.md)).
+- [ ] Resolve the **ADR lifecycle** — the pipeline hooks into the existing ADR
+  process ([`docs/adr/README.md`](adr/README.md)), it does not restate it:
+  - New structural decision → draft a **new ADR** (the [ADR requirement](adr/README.md)).
+  - Reverses/changes a recorded decision → **supersede** the old ADR (status +
+    forward pointer).
+  - Clarifies or adds a detail/consequence → **amend in place** (dated note).
+  - Reversible convention or style → `docs/conventions.md`, not an ADR.
 
 ### 5. Realisation
 - [ ] Deliver as one focused PR — delivery conventions D1–D5.


### PR DESCRIPTION
## Summary

Formalise a **five-phase work intake & triage pipeline** — deduplication, study/go-nogo, prioritisation, planning, realisation — for features, fixes and external contributions, decided in **ADR-0014** with an operational checklist.

## Why

Epic #102 was closed `completed` while its Renovate custom-manager sub-task was undelivered — it survived only by ad-hoc re-homing to #20. The pipeline adds a **closing-integrity** rule so scope stops leaking on close.

## Changes

- `docs/adr/0014-work-intake-and-triage-process.md` — the decision (MADR format)
- `docs/work-intake-and-triage.md` — operational checklist
- ADR index + roadmap Decisions row
- **ADR lifecycle** (create / amend / supersede) hooked into the pipeline, pointing to `docs/adr/README.md` rather than restating it (conventions L2)

## ADR

- [x] ADR added — this PR **is** ADR-0014.

## Scope

Process/docs only; no workflow or CI changes. The Renovate custom manager (#20) and Plumber (#153) are the first items re-run through this pipeline, tracked separately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7svXaHyT5whPgED9ZTJ98