### PR TITLE
feat(ci)!: publish only the platforms upstream supports

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -95,7 +95,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          platforms: linux/amd64,linux/arm64
           build-args: |
             TERRAFORM_VERSION=${{ matrix.tf_versions }}
             AWS_CLI_VERSION=${{ matrix.awscli_versions }}

--- a/.github/workflows/push-edge.yml
+++ b/.github/workflows/push-edge.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          platforms: linux/amd64,linux/arm64
           build-args: |
             TERRAFORM_VERSION=${{ env.TF_VERSION }}
             AWS_CLI_VERSION=${{ env.AWS_VERSION }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -98,7 +98,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          platforms: linux/amd64,linux/arm64
           build-args: |
             TERRAFORM_VERSION=${{ matrix.tf_versions }}
             AWS_CLI_VERSION=${{ matrix.awscli_versions }}
@@ -112,7 +112,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          platforms: linux/amd64,linux/arm64
           build-args: |
             TERRAFORM_VERSION=${{ matrix.tf_versions }}
             AWS_CLI_VERSION=${{ matrix.awscli_versions }}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Retiring a version stops **new builds only**: every previously published
 fully-pinned tag (`vX.Y.Z_tf-A.B.C_aws-D.E.F`) is immutable and stays pullable
 forever — pin one of those to keep using an older combination.
 
+**Platform support policy:** images are published for **`linux/amd64` and
+`linux/arm64`**, the platforms AWS distributes a Linux CLI v2 bundle for
+(see [ADR-0019](docs/adr/0019-platform-support-follows-upstream.md)). As with
+versions, dropping a platform stops new builds only: tags published earlier
+keep the manifests they were pushed with.
+
 ## 💡 Motivation
 
 The goal is to create a **minimalist** and **lightweight** image with these tools in order to reduce network and storage impact.

--- a/docs/adr/0017-arch-native-aws-cli-bundle.md
+++ b/docs/adr/0017-arch-native-aws-cli-bundle.md
@@ -47,5 +47,9 @@ their prior behaviour — pending a decision on the published platform list.
 
 ## More information
 
+> **Amended 2026-08-03** — the follow-up above is answered by
+> [ADR-0019](0019-platform-support-follows-upstream.md): `arm/v7` and `386`
+> leave the published platform set.
+
 - [AWS CLI v2 for Linux ARM announcement](https://aws.amazon.com/blogs/developer/aws-cli-v2-now-available-for-linux-arm/)
 - ADR-0016 (single verification oracle) — the failure that surfaced this.

--- a/docs/adr/0019-platform-support-follows-upstream.md
+++ b/docs/adr/0019-platform-support-follows-upstream.md
@@ -1,0 +1,76 @@
+# 0019 — Published platforms follow upstream AWS CLI availability
+
+- Status: Accepted
+- Date: 2026-08-03
+- Deciders: @bgauduch
+
+## Context and problem statement
+
+The image is published for `linux/amd64`, `linux/arm64`, `linux/arm/v7` and
+`linux/386`, a set never recorded by a decision — it predates the ADRs. AWS
+distributes a Linux AWS CLI v2 bundle for **`x86_64` and `aarch64` only**:
+every other architecture returns 404 on the download endpoint (verified
+2026-08-01, #161).
+
+Two of the four published platforms therefore cannot carry a working `aws`.
+Before ADR-0017 the Dockerfile installed the `x86_64` bundle unconditionally,
+so `arm/v7` and `386` images shipped a binary their rootfs cannot execute
+(`qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2'`). ADR-0017 made
+the install arch-native, which fixed `arm64` and left the other two with no
+bundle to install at all. No user report was ever filed for either platform.
+
+## Decision drivers
+
+- A published platform is a promise the image works there; two of them cannot
+  be kept.
+- Every combination is built for every platform, so the matrix multiplies CI
+  cost — the same pressure ADR-0015 addressed on the version axis.
+- The rule must not need re-arguing when upstream adds or drops an
+  architecture.
+
+## Considered options
+
+- **Keep the four platforms** and let `arm/v7` and `386` ship a broken `aws`:
+  the status quo, and the defect #161 opened on.
+- **Build AWS CLI v2 from source** for the two unsupported architectures:
+  restores coverage, but loses the GPG-signed upstream bundle and adds a Python
+  runtime plus qemu-compiled native dependencies to every build, for platforms
+  upstream does not support and nobody asked for.
+- **Publish only what upstream supports** (chosen): the platform set is derived
+  from AWS CLI availability rather than declared independently of it.
+
+## Decision outcome
+
+Chosen option: **published platforms follow upstream AWS CLI availability**.
+
+- Images are published for **`linux/amd64` and `linux/arm64`**, the two
+  platforms AWS ships a Linux CLI v2 bundle for.
+- The set is derived, not fixed: if AWS publishes a bundle for another
+  architecture, that platform becomes publishable under this ADR without a new
+  decision; if one disappears upstream, it leaves the same way.
+- **Dropping a platform stops new builds only.** Tags already published keep
+  the manifests they were pushed with — the immutability guarantee (ADR-0018,
+  `docs/rollback.md`) covers the platform dimension as it does the version one.
+- This is the platform counterpart of ADR-0015: support follows upstream on
+  both axes, so "supported" keeps meaning *works and is maintained*.
+
+### Consequences
+
+- Good: every published platform runs both bundled tools. The `arm/v7` and
+  `386` manifests, which could not, stop being produced.
+- Good: four platform builds per combination become two, on every
+  image-touching PR and on every release.
+- Bad: consumers on 32-bit ARM or x86 get no new images. They never had a
+  working `aws` on those platforms, so the promise being withdrawn was never
+  kept — but the withdrawal is user-visible, hence the breaking-change marker
+  on the delivering commit.
+- The representative CI matrix (#152) and any future multi-arch structure tests
+  inherit this set rather than defining their own.
+
+## More information
+
+Study and decision trail: #161 (maintainer `go` 2026-08-01), delivered in two
+parts — [ADR-0017](0017-arch-native-aws-cli-bundle.md) made the AWS CLI install
+arch-native, this ADR trims what is published. Version counterpart:
+[ADR-0015](0015-version-support-follows-upstream-eol.md). Upstream reference:
+[Install or update the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -90,3 +90,4 @@ Rule of thumb: *clarification → amend; reversal → supersede.*
 | [0016](0016-single-verification-oracle.md) | A single verification oracle shared by human, agent and CI | Accepted |
 | [0017](0017-arch-native-aws-cli-bundle.md) | Install the arch-native AWS CLI bundle per target platform | Accepted |
 | [0018](0018-single-owner-publication-matrix.md) | One publisher per tag: `latest` follows releases, `edge` follows master | Accepted |
+| [0019](0019-platform-support-follows-upstream.md) | Published platforms follow upstream AWS CLI availability | Accepted |

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -49,7 +49,7 @@ CA trusted system-wide) so the checks below need no manual setup.
 
 ### Stays in CI (authoritative gate)
 
-The full multi-arch build (`amd64,arm64,arm/v7,386`) + end-to-end
+The full multi-arch build (`amd64,arm64`) + end-to-end
 `container-structure-test` run on GitHub Actions — the final say. The local harness
 covers lint, base pull, pin install and assertion values (the fast checks that
 catch most breakage); it does not reproduce the multi-arch build.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,6 +67,7 @@ to green; the human owns the merge).
 | Version sunset | Support follows upstream EOL: latest three minor lines (two HashiCorp-patched + one grace); retired versions stay on immutable tags (#157) | ADR-0015 |
 | Verification oracle | One script, three callers (`scripts/validate.sh`): the same fast structural checks for maintainer, agent and CI; built in passes (#152) | ADR-0016 |
 | AWS CLI bundle arch | Arch-native bundle selected from buildx `TARGETARCH` (`x86_64` / `aarch64`), per-arch `.sig` in `security/` | ADR-0017 |
+| Published platforms | Follow upstream AWS CLI availability: `linux/amd64` + `linux/arm64`; `arm/v7` and `386` retired (#161) | ADR-0019 |
 | APT package pinning | OS utility packages **pinned** to exact versions (refreshed when Debian supersedes a pin); bundled binaries stay pinned + GPG/checksum verified | ADR-0010 |
 | Base image | Debian 13 (`trixie`), pinned by immutable `sha256` digest | ADR-0011 |
 | Rollback policy | No mutation of immutable full tags; consumers re-pin an older tag | `docs/rollback.md` |
@@ -150,7 +151,7 @@ Urgent: current versions are frozen at end-2023 and accrue CVEs.
 - Add `pull_request` trigger to `lint-dockerfile` and `build-test` — ADR-0013 *(#103, closes #46)*
 - Add `concurrency:` to every workflow (cancel stale runs) *(#103)*
 - Harmonise buildx `cache-from` / `cache-to` across workflows *(#103)*
-- Restrict multi-arch build (`amd64,arm64,arm/v7,386`) to publish workflows only *(#103)*
+- Restrict the multi-arch build (`amd64,arm64` — ADR-0019) to publish workflows only *(#103)*
 - `scripts/validate.sh`: argument parsing, semver validation, correct platform string, `set -euo pipefail` *(#104)*
 - Extend `container-structure-tests.yml.template`: negative tests (non-root user), binaries-in-`PATH` checks *(#104)*
 


### PR DESCRIPTION
## Summary

**PR B of #161**, the second half of the platform defect. AWS distributes a Linux AWS CLI v2 bundle for **`x86_64` and `aarch64` only** — every other architecture 404s on the download endpoint — so the `arm/v7` and `386` manifests could never carry a working `aws`. #162 (ADR-0017) made the install arch-native, which fixed `arm64` and left those two with no bundle to install at all. This PR trims what is published to what upstream supports, recorded as **ADR-0019**.

| Before | After |
|---|---|
| `linux/amd64,linux/arm64,linux/arm/v7,linux/386` | `linux/amd64,linux/arm64` |

- **`build-test.yml`, `push-edge.yml`, `release-please.yml`** — the multi-arch build lines (four occurrences across the three workflows; `build-test.yml`'s single-platform structure-test build is untouched). Four platform builds per combination become two, on every image-touching PR and every release.
- **ADR-0019** — the platform set is *derived* from upstream availability rather than declared independently of it: an architecture AWS starts shipping becomes publishable without a new decision, and one it drops leaves the same way. This is the platform counterpart of ADR-0015 on the version axis.
- **ADR-0017 amended** with a dated note: its open follow-up ("decide whether `arm/v7` and `386` stay") is what this ADR answers.
- **Docs** — README states the supported platforms next to the version-support policy; roadmap Phase 4 item + Decisions row; `docs/agent-framework.md`'s description of the authoritative CI gate no longer names the retired platforms.

Roadmap phase / closes: Phase 4 — closes #161 (PR A shipped as #162; both halves now delivered)

## Breaking change, and what users see

Images stop being published for `linux/arm/v7` and `linux/386`. Nobody loses a *working* image: those manifests have always shipped an `aws` that cannot execute (`qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2'`), and no user report was ever filed for either platform. Tags published earlier keep the manifests they were pushed with — the immutability guarantee covers the platform dimension as it does the version one.

The change is marked breaking so it rides the pending `v9.0.0` (#159) alongside the version sunset (#158) and the `latest` ownership change (#163), rather than triggering a second major.

## Out of scope

- **Rebuilding or deleting existing multi-arch tags**: immutable by policy; #137's `skopeo copy --all` migration preserves them as-is.
- **The representative CI matrix**: #152 PR 2 inherits this platform set instead of defining its own.

## Verification

`./scripts/validate.sh --fast` green; the three workflows parse as YAML; no `arm/v7` or `386` reference survives outside the ADRs that record the decision. The `--full` multi-arch build is CI's gate, not the sandbox's.

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (link: `docs/adr/0019-platform-support-follows-upstream.md`)
- [ ] This PR is **not** a structural change — no ADR needed

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuV9sBnSE2UPotkkZTgXjr)_